### PR TITLE
Importing the SVG source files for the openbadges badges from the old bc...

### DIFF
--- a/misc/openbadge_badges/badge-creator.svg
+++ b/misc/openbadge_badges/badge-creator.svg
@@ -1,0 +1,651 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1"
+	 id="svg3004" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi:docname="creator.svg" inkscape:version="0.48.1 r9760"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="108px" height="108px"
+	 viewBox="0 0 108 108" enable-background="new 0 0 108 108" xml:space="preserve">
+<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:pgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:pgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g id="g3014_1_" transform="translate(0,376.07634)">
+			<g id="g3016_1_">
+				<defs>
+					<rect id="SVGID_1_" x="8.996" y="12.472" width="94.089" height="88.952"/>
+				</defs>
+				<clipPath id="SVGID_2_">
+					<use xlink:href="#SVGID_1_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3022_1_" clip-path="url(#SVGID_2_)">
+					<g id="g3038_1_">
+						<g id="g3040_1_" opacity="0.75">
+							<defs>
+								<path id="SVGID_3_" opacity="0.75" d="M97.635,57.893c0,24.043-19.487,43.531-43.529,43.531
+									c-24.041,0-43.53-19.488-43.53-43.531c0-24.04,19.489-43.529,43.53-43.529C78.147,14.364,97.635,33.853,97.635,57.893"/>
+							</defs>
+							<clipPath id="SVGID_4_">
+								<use xlink:href="#SVGID_3_"  overflow="visible"/>
+							</clipPath>
+							<g id="g3042_1_" clip-path="url(#SVGID_4_)">
+								<g id="g3044_1_">
+									<g id="g3048_1_">
+									</g>
+									<g id="g3046_1_">
+										<g id="g3050_1_">
+											<defs>
+												<rect id="SVGID_5_" x="8.996" y="12.472" width="94.089" height="60.786"/>
+											</defs>
+											<clipPath id="SVGID_6_">
+												<use xlink:href="#SVGID_5_"  overflow="visible"/>
+											</clipPath>
+											<g id="g3052_1_" opacity="0.64" clip-path="url(#SVGID_6_)">
+												<g id="g3054_1_" transform="translate(147.3794,85.8701)">
+													<path id="path3056_1_" inkscape:connector-curvature="0" fill="#BDC620" d="M-89.623-14.21l45.328-10.739
+														l-4.811-11.497l-29.209,11.827l31.233-28.749l-11.184-7.164l-28.445,35.326l15.784-46.417l-13.273-0.455l-8.127,44.384
+														l-8.562-45.706l-12.344,5.011l14.763,41.621l-27.216-34.201l-7.569,10.913l30.339,27.546l-34.05-15.046l-1.419,13.205
+														l40.594,9.439l1.426,2.298l3.771-0.895l1.432,0.715L-89.623-14.21z"/>
+												</g>
+											</g>
+										</g>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="g3058_1_" transform="translate(57.3389,463.82834)">
+			<path id="path3060_1_" inkscape:connector-curvature="0" fill="#80AA38" d="M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248
+				H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3062_1_" transform="translate(57.3389,463.82834)">
+			
+				<path id="path3064_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3066_1_" transform="translate(72.5313,439.77264)">
+			<path id="path3068_1_" inkscape:connector-curvature="0" fill="#C3D025" d="M-61.955-354.134h87.259l-2.13,6.917h-82.202
+				L-61.955-354.134z"/>
+		</g>
+		<g id="g3070_1_" transform="translate(72.5313,439.77264)">
+			
+				<path id="path3072_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-61.955-354.134h87.259l-2.13,6.917h-82.202L-61.955-354.134z"/>
+		</g>
+		<g id="g3076_1_">
+			<g id="g3082_1_" transform="translate(63.3096,106.6533)">
+				<path id="path3084_1_" inkscape:connector-curvature="0" fill="#C3D025" d="M-58.546-48.095
+					c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799c0-24.262,19.668-43.928,43.928-43.928
+					c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669c0.656-2.941,1.054-5.981,1.158-9.095
+					l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66l0.715-1.86l3.229,1.242
+					c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665c-0.748-1.979-1.618-3.899-2.604-5.749
+					l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209l-4.565,0.718l-0.311-1.969l3.411-0.534
+					c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119c-1.622-1.334-3.334-2.561-5.12-3.682
+					l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908l-1.251-1.55l2.694-2.175
+					c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952
+					l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314l-1.859-0.719l1.248-3.227
+					c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626
+					l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566l-1.969,0.306l-0.529-3.41
+					c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053
+					l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609l-1.553,1.247l-2.17-2.699
+					c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394
+					l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+			<g id="g3086_1_" transform="translate(63.3096,106.6533)">
+				
+					<path id="path3088_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-58.546-48.095c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799
+					c0-24.262,19.668-43.928,43.928-43.928c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669
+					c0.656-2.941,1.054-5.981,1.158-9.095l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66
+					l0.715-1.86l3.229,1.242c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665
+					c-0.748-1.979-1.618-3.899-2.604-5.749l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209
+					l-4.565,0.718l-0.311-1.969l3.411-0.534c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119
+					c-1.622-1.334-3.334-2.561-5.12-3.682l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908
+					l-1.251-1.55l2.694-2.175c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604
+					c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314
+					l-1.859-0.719l1.248-3.227c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398
+					c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566
+					l-1.969,0.306l-0.529-3.41c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27
+					c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609
+					l-1.553,1.247l-2.17-2.699c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277
+					c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+		</g>
+		<g id="g3096_1_">
+			<g id="g3102_1_" transform="translate(133.7676,136.4482)">
+				<path id="path3104_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-84.59-96.67h9.725v0.986
+					c0,0-0.304,1.084-1.52,0.761l-0.76,0.169v18.668l-2.584,2.41l-3.038-2.189v-19.059c0,0-1.519-0.105-1.824-0.433
+					C-84.894-95.685-84.59-96.67-84.59-96.67"/>
+			</g>
+			<g id="g3106_1_" transform="translate(136.9014,135.9277)">
+				<path id="path3108_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-85.749-95.822h6.686c0,0,0.911,0.548,0,0.602
+					C-79.975-95.165-85.749-95.822-85.749-95.822"/>
+			</g>
+			<g id="g3110_1_" transform="translate(143.8926,133.6768)">
+				<path id="path3112_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-88.333-92.151v18.619l-0.861,0.327v-18.668
+					L-88.333-92.151z"/>
+			</g>
+			<g id="g3114_1_" transform="translate(156.355,123.4932)">
+				<path id="path3116_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-92.94-75.549l-0.01,0.01
+					c-0.512-0.498-1.208-0.805-1.977-0.805c-1.568,0-2.841,1.272-2.841,2.839c0,0.771,0.308,1.466,0.804,1.979l-0.004,0.004
+					c0.019,0.016,0.035,0.03,0.055,0.047c0.096,0.093,0.198,0.177,0.306,0.257c1.804,1.601,2.943,3.932,2.943,6.533
+					c0,4.829-3.916,8.744-8.745,8.744s-8.744-3.915-8.744-8.744c0-2.559,1.105-4.857,2.859-6.455
+					c0.763-0.509,1.267-1.376,1.267-2.366c0-1.567-1.271-2.839-2.84-2.839c-0.775,0-1.478,0.311-1.99,0.815l-0.02-0.021
+					c-3.029,2.645-4.948,6.529-4.948,10.865c0,7.963,6.455,14.415,14.415,14.415c7.961,0,14.417-6.452,14.417-14.415
+					C-87.992-69.02-89.911-72.906-92.94-75.549"/>
+			</g>
+		</g>
+		<g id="g3118_1_" transform="translate(0,376.07634)">
+			<g>
+				<defs>
+					<path id="SVGID_7_" d="M10.102-318.612c0,24.345,19.736,44.081,44.082,44.081l0,0c24.346,0,44.083-19.736,44.083-44.081l0,0
+						c0-24.347-19.736-44.083-44.083-44.083l0,0C29.838-362.695,10.102-342.96,10.102-318.612"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3120_1_" clip-path="url(#SVGID_8_)">
+					<g id="g3126_1_" transform="translate(201.0342,157.2715)">
+						<path id="path3128_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-109.454-506.695c0,0-0.747-0.257-1.357-0.654
+							c-1.307-0.851-21.334-0.217-21.334-0.217l0.667-0.552c0,0,20.472-0.285,21.284,0.129
+							C-109.384-507.577-109.454-506.695-109.454-506.695 M-143.388-500.48l-0.02,3.125c0,0-0.077-2.039-0.916-2.181
+							c-0.838-0.139-0.358-0.953-0.358-0.953L-143.388-500.48z M-109.159-508.086c-0.732-0.806-4.407-0.744-5.435-0.761
+							c-5.566-0.082-12.748,0.203-17.945,0.163c-0.21,0-0.935,0.348-0.815,0.645c-3.694-0.022-1.77,0-6.23-0.066
+							c-2.414-0.037-6.245,0.872-6.355-3.396c-0.061-2.127,1.896-4.011,4.221-6.279c-1.47-0.462-2.962,0.525-4.452,1.344
+							c-0.731,0.709-1.227,1.19-1.838,1.785c-2.278,3.288-3.179,6.6-2.667,9.929c2.038-0.378,3.535,2.415,2.094,3.72l-1.271,0.012
+							c-0.602,0.004-1.083,0.619-1.076,1.366l0.022,2.96c0.006,0.748,0.5,1.253,1.102,1.25l6.417,0.038
+							c0.603-0.003,1.083-0.618,1.074-1.369l-0.021-2.955c-0.005-0.751-0.502-1.356-1.099-1.352l-0.802,0.007
+							c-1.395-3.988,1.211-2.796,3.79-2.755c4.848,0.074,2.567,0.045,6.838,0.074c0.243,0.297,0.121,0.839,0.791,1.124
+							c0.415,0.172,22.823,0.246,23.283,0.14c0.462-0.108,0.343-0.331,0.512-0.497C-108.8-503.849-108.279-507.122-109.159-508.086"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		
+			<text transform="matrix(1 0 0 1 10.709 81.4541)" fill="#FFFFFF" font-family="'Arial-BoldMT'" font-size="11.7746" letter-spacing="4">CREATOR</text>
+	</g>
+</switch>
+<i:pgf  id="adobe_illustrator_pgf">
+	<![CDATA[
+	eJzsved6IjnQKPzdAPcAtrHBpI7Q7Ux0zjmNTWjbjDHgBnZ33h/n2k+V1JlOhPl23/PMzg4DarVK
+KpUqqUqKx84uM8VWr6Fk+CwTjcTjZVWpD3vqWpSURvc7ndFgqGJR4iIZZcUsA5WK+9KLVvFGUQft
+XneNPMpy8LCGbyfOVGUw7HWje73OlzJIRhNJeHTVHnYUeNiot96VTJO2kOkqf2cHf70ndejQXKU+
+hHpSjoX/+Wh+jRWiZ8f4vN79qz4YtP8HnrJ5XuKhrNQbdVvt7nup989alBPZKC9IUT7PRAUBH++1
+L5SBs05WzmMlQcrKIr4hyllByPPwCpflC5IM71V6zdGX0h2eqb2mMhiUe52eOliLln/Vu9Hj+js8
+qUfvlU6n93e01Kk3Py2v1HrdIVQtqu16J1PqdVrHV5anJ4rSUlqudYr74kut3VEAhV/1YZRlEdvF
+fZZ7KY3andbJ6KuhAHJ5WcZi/oV06noAvYGO4XcsLrzsf0HJpTIcwogBBs7YxW7JOhAoJH8SjxfK
+e5tMMGD9Oak1q/b6X3X1c0BxJQKiOPwELIlRQWSyIq13pXz1OzBTBKs8I2IdOY+f5netJgyK1GIL
+2AS0EBVlHj4LBUGvYyJc+aut/L0WPel1FYqTojq8pHMuCAxDP+mTi1FHUa+77SEdZ3Ffpkg57rWU
+DtQ33q916gQX5A9rftIKV3X1XRkCofQ6oyEhZ0mHAEg/qv9ScO5ZCuC0r3Svejekjxwv4ICQdGC6
+Clw0z3JRLk/az+dhuIIBkjU/acvYDraiN1+AeTqDmTtV2+/t7prWucLLrtpumbMJMCT6QfqflSx/
+Zf0v7SiMeThUulrHgYrKxxaqYLLHlwCx2m2Ve1+I+AEuJiCHLlBKp/dOnxnfyRN4fdSPPEZ4Ofc9
+6g2VAbTVUaJyPveu1v9Soiwn5YqttgKLvz3IAXF333PlptJqdzr1XLXeHA2V3MkQSFnJnerVIrlr
+4406rVInreXqzbYKNPHWUf7J1c069P06abypN66QNyM5hb6qWF5VjFfbtPk2rdO21Gkbdbqk+Uiu
+R+v2aN2epW7PqNujXRnRqiNadWRWjeRGRt1W/f1dUXMt6KCi5JqA79xgqKgdHMVAaSLV5RqjTkcZ
+5vp1FTHQ/8jBG1/1bqvRASypZKVCa61cs9f/BUTyMczBym0puFZztA8GuGy3N2wpb7liNXc66NQH
+HxGjqA8s/avdHZmV9H9/Kd3c18hZHBmrp//bU1tvCjTV7ir4/as+aI46+EOvUIdyDfr3CAQCDLLV
++7ubU/5pdupf5CtQV7tZ78ALxltvsIDb3fFuvAMT7ChfPRAib0PzF8UEsOJ2H0c+6NebSq5IJ6Oo
+EZv2TzXXQxrptqBLOeWL/EMIGVBMGtV/0DbJL7OcFrbaf7WRQAykGTi/N769qXU6o9WR2iM9JSvF
+6Df5RZqL5N7aMGCNPAByrg9wei0kEDLX5jpr1AeK0UHyA6oOP3qjAZBIJFe0kGjV8r1IKaNqdK5K
+UbNPy/et5LpvVNqnlU5ppVNLe/q4T2mNa1rj2trMNX3UwpkCaZ2zvE0n4qveVJHegdWTavUmWRB0
+SdMVHcl9jLrvdXX01amPhrAOQRp85pp1eC9yVSUcVDx4uRqAzDBFBf9C2FS12+yhuF+LvlgFrF3a
+PuZsD3O2mpRpXz3QRoEP6k1Gr9SRcvWrr0Qe2TyrLWfg83wO0KJ8j+od+JHPtbtvsCyGvyyLDVFB
+KgCvBC0H8Iw/IqzE4pqDNT8E+K3221sOxvRFBHKur/ZaoyZwhDa0OETeBs1Lcu70S3mvRyOsLOaA
+AeD6ibJyIVfvwwv/aL2QpVxF6YCWwrGCRrSw2P5H6b4rUU5gsHIHyPjl8tdXo9d5ydF/bSMXKTpf
+AL1nMDcoOSIn/QjR/846I3i0q/ZG/f3uWy+SoArjFVA+oum08ROYGuh9WoH57XLUHirZeruf9G0I
+hJeqROlDeJn81P8NfruivIEOZb5OS6vdv5ROr29p1iiBJRS9rav94KbPOvVuXY2ScqPlozZIv7M6
+4Mhs2ywL0ShoAH2UAn/pnXMA8KlgeRQCUH34AQorsMCB0Tb9ae84LQtu77KJOoYaLamjwUf0qtfr
+GM3aHxmta8WkFOv/N2CckRe6p12KoHFIWgUnJFAt/3NQoLY3BHj4X269XAc5TpSfdtMNgMtzAxJ9
+NglhEZbXHnyZ9GQpOUOW3Owol79A7fryaw2xAfy+BYRIuJvZ295XH03P6OVHva+QNocfNVLz0mhQ
+RPli5bGZjD/znfgFmT5BM2r4C+RQJHfYBd2L/IiuATa6PcBf7qT+pUTTkdxlG+w6RX/KRE8jjMWK
+YaN39YhuQzHRu1/w4wC+/ISiv6MsEz2OPj4z0RYU312QinegnVDeuB6JglB6g39dehDlJM6/F1kx
+z/I8mFRZVpAkPo+dyDKMJAscfBEZVs5jSR7/K8AXDgoY6Tf2l/93sfYIpfVRZ/g8aTcAQrYgMhzB
+VkHOSzz5wnAcIlJm2Lxut94Vw/ea9eg1oUAgWZP+Aon4rA6GENhzCPWsEbq3Tn8GGfXd/0TG/Bxn
+zchZyeiGDm2SRXQEzVlnYGyUpMI0q5Vl6CPKi7CZ/08rhoYchR6Na33VXSqV+rAeib/k9N9AGPir
+TWyUuvqL/BY5gZOiuX14nIAWosD9Gr262oo20aES5aKNzghYWDpMVTBcQtZE9blL6zLRXAnYNq3Y
+B36pRgftr1GHzBmtwlmagsnsgq2nKt3mL2im3YqiX5DWYz1B0ud5UeRF726x1m4hVeculHrnrAco
+hgKbxoXOmRdQNzrK2CBYNtrSEd4e9NBTBjhUiCMyZDdMlAdWNVDOigztL614rICIvKij56D9PwSV
+UdPPRd9wUoIxBjDoP2kV4LVam/16SwMkaN2BHmhoLejz0+q3sw581EGqGpNDiwb93pAWrWNfo8XR
+sGd0VRt37u746KTXUlxJFl7756vThccZ0JvUdgMsUQ0ImHNqndb63U3MoX1LreYHWMiq4iB4/Sl+
+DH/1NeQklruDl7/q6mAdBMDlEM1ne9W/6gYBkfKBR70uCA9jJrSK6f/12AEZrYRATKfX/MTFE4wZ
+veacCHPacTXahIewIcYGxHGpDE/IIILHZ609p+mfEROsLyZCjb9dB6YbhvADZ/V/00Jf+yv0Useq
+/zJF4/Cao8Gw9/XvcrLfR4drgzrq5aiJwRILS46/fV1AX/5DXfl/YZUO3v7+D0vjf3kZDDrt5v92
+XsyL+SyHXghNIfYa668ws/vr32a9nChkZVkKGsw/oUj13x4MyzBZgWXZoNH83W4NP8KMSKv4745K
+KmS5gsQHDepDwf3EMKPSa/7Lk6WbgV4DavSGoBAcKW9DGhERZmjj7/wHhD/hepe9kdpUSCDSvy79
+QUb92134Uob1FihDs/ZDnrEfi7qLJgx1WSqTl0l0FIP/0bAo8tXS0OXNLgmmKvX+ubs3/CGkv1hc
+VJV6kXiRtIXOyhhtVZAF/CfA54Q0jluRylWvT2rZ2/esftMetBvtTnv463JYH5peK8pcnK/VOr2e
+evr2NlC09kXPqmTR9etNaFmrKnnWvUAGVP1nqAR1G0O7NLHL2Nxap6NhfzQMcGx5OOM+u2DH9+Dt
+d7qDilULBRaRrk1BCNzf1LvtwQdMswX52tuSMNEElgjPsjTDc4V8wQMhBHO7pncywTJSlvEhvD0L
+s2cMByKgw3AGk6Cu6FG9+z6qvyvRs15fRwoJsTTe0V+gQZiXpovOons6BAhu/lE3JTorYDKbsKT0
+Tpp+BkMU7A/0FzS/ullH73ulPeh36r+O6+qnjnS+QGaO/ONAOokPtIoCGtBIVqul7oXSuepd0Hp0
+snqDNg6EPGV1xU82YiHDvsoZA9QWQvHCwdb0ARMkhpzTW1Mt8Vo4ZOH6Lnh38jLxtd9tKf/U2uog
+YIk6X7lUmr2u7iIWpYLg10MLJfuwC1wqVm7Be9YsK52OSZms6FevDLJ4qFOFZ4t7PWAvva51GXEe
+I7oyLcHHY6XVHn1ZONLz+AJwW4ZazKaiRjGCWhlGzRVg3QJwZQsXum/Sc6qwVskQfqyNPRJ46l9K
+9Er5ZxitttrDOiWbcV7KRN+MbgIfxZC/6BDeGm/WWrOvA+j9pah93K9ybgg4Xmh22v1os4d+k3+i
+GP7Y0y3hoM4MhmrvU1fxEoy2mKKM+6rCIFyLiE7QUHZLpc/ifm3U6ehTpcW8w1PD7DAZq7U7KpFO
+mb9gCnpqtFGH5djUmabTnrXpoZdKZ68+BHj7GAW4XxlYuINHzaNes95BYrHWtVa4QicLQg0WMmRp
+GtQUWNOkqIJM2KvEs/kJBCAuRuvylvKF8LKY0PTMwhhZo86zNdblzY6QXgAWSKKhOaETgSOddhf+
+EymBZjt2LRBZhY8iaEytKMkS61PRnFnBk5VivVq9qRQxFDyoMumwo7Yvt/IWYZLAh6c1sy0nsTHR
+jKirlj7vK7gN/ZdC6N2N2rwFCAFtU4y5PMd6SUXEplUoBmjm1mbXsWqzp7aU1jiLieZOekPbYw8Z
+ZRFOXLS47yeQbCo5SJDq2WX0CNkvRoFhQCWRJH5KOYFwqjHtK1cJQpstoygoa6LgwioKWKtOi1VP
+ndLFuh9OIe5i0CzKXOwk3SB3dDIYORSYD3bscGn1YMAFc5Of9pVaOLkbKkNKVhnCOqqOjXwMjTqq
+L63yMYBOdCg503WS+9lrZAef7X4DevPpNLWdFftgVahgXei60bgi5HxDD26wvOXVCzLeeqejvzKw
+8xRndQw4VwcKjk71r9nsdToGrwmCbkhbTZPC+KeDXgOjA6OmyGU858Od9Mmk+lK++0KyzS5rjarp
+9kzlK9ruEuUKzRU3pWScEtxQ1eyogKouNDrEcI5B6Dk2HSusyUZsLaut7AADa7J/eU9C8yv7BUA0
+qNfZy2z0VmkAvmDqWtGnxOXt6dlTMvoX598haKav9t7aTpE0VodqsL3hh04+ASPtv399ZunOptm6
+20D+6WdR3fUGT1oaYGBZQB2li4peKyRuP3xaG2S7ynvd9E9x7ljBzATTd+HeUAfWnbZKCpwrdqFH
+YGlhWqVNVLgSnEHDDcy89KlLhtnvNH8F4AxZVBsWq39TbzBBHz31fwIaa4KRHlAFJsiYIZc6b91h
+ttWxEHYIIoM1NcT0Wn/MmW3m3eiCtERSP3tvb9mhZRwuNNTvq9kPF+/SWIOqJfbSp0ETMwhctTXs
+TsJIB51634+IKSr76lvPEIteHJ8y80GjPfyq+0ygUdXOL4LGg7lfQYSDoXyNujoIGrb6rvNE3zr+
+a7vRRj7vz5E0xk7kSWiyCZo5O17ojo0vh9fZbvPrl99iR3okQaGBRNuzOLR5dw4JCBp81FuYDRdq
+DYKyMsjWu109ojEEnqwj5xm3IcEUqOq4+uzKYFmU5XV9ZyKU/8kBqjvma3VU6PVbow==
+	]]>
+	<![CDATA[
+	0KOz0XsQEQz9OCaB3OzpI7PEvPtJdFDfaFbtuAvZOc/KEF02XWUw8CbDwbCTbVHI/X7Lpz2gLyrv
+Q5ENNkurG626QcdWNehBxP23lbiZLCd6Yh8aRHXRssftJuANdtfQti59pknjFxZXoOhR891J1qKH
+zO1r3nR/ftxSBu33rkXAYBq+27gRQeZ4WcmrUhuPULDQcEH2bC9IBKIEGowag+CZC9+xAMlsEY1/
++VlnhGlZqdVz+Q38lxBM/JAE2/rW+UJGPvCdTNIjmwabgPUOVNqKNn5FKyroomqAMgRIMjlZwY2u
+YEQ2X6wXVVFNwEmpruvTxs1GA6XSa5bwZzjhgVwA1j8qZx2z72FewoWpqF3rTpov66L1/dXcYbtj
+ZCi4SmSiVTe7A9NkdZWfY0x1vBaZbt1fPvBhLrTiqNvUp9VzOdIFYpWtoiz4V7YoLHYTvqjXthjx
+Oo+8vNmtfjWUFvXPjBv4ormzc9b+R+mcKeqb0hza0QqN4EEwl8Ae6MEcDpt9zE3d1TVTq5+I+hJ8
+HEV2Rx3xFYTy0+l9rFxVHB2DQszWOATacwwdntzpnbTiSsufH2/n7P1tDCAixdxN480HZ6rSbA/G
+fYnwCAdBE1PdntGTaugTwWyPZGpdWWOSrF3APRUXx+XYrHz0/t5rt5RxuCQLlGzK4KEUY0RyWf9L
+OYZl2e53lKLdgRXovLWczBSdr0qEJHJWqb1cqfV+389M1StW8GSPrraB0mnr1nYA/9Lf1jLzfp2E
+ZXz6izQEpNzrtiwawnTv7rdgnbbf2iG9OvZWcI+OnBOF9uDEo7Agz/Lu1QeYPFE8AWH4oUQ17h3V
+mMQg+veH0o0O6n9hq/Wu9ZSuKHYiWh9gsZZSXqkZoS/Z6PWANAmf9sZ+9UZRWCLdaK8bVRAp0DKC
+ps2919td9BdaAKWjAMx4tQuyLjrsYRNNJdomzsV6tFP/hWE2eNJEm66k6GDU/MDu7XcrRGczm6HQ
+usCkQH5Ge28m+PYgOup+YuZrNjROm2q77y+z9craxO13mzA2Bwn7vecx+WFfJ8dUlYnCPAnUyyEw
+bGATvjVZOi5qNRebaq9RH9JTpnxXfeC2ftiXbNvvripY+I3yEGC94wQsezD290PlRXqgiWBX2/i5
+siSh+voTQsesTW66O7qE+5JkL+rEVyvU3zI2jSwOY8/KVFFB0XiBvfdtXSArUdODg/tBqoFWYnp4
+3JBoqXvlawPZql4EeKRslUsW1TG49pFhIrr6RAwsE6O8pva+QM7/3VM/rVAme9MY92SvTdvRC3/r
+1uQ2xLLAsDxTnfJyP+gvXantL3zjNsCENoCAtr7v66bXaxLuWqoHMDxW0z+wDyFq6t31cROZ8Kmx
+C0i065xulY973V7zA1CulE0b+bCtB9G5+wbHX66AgKRZZk6eIri6YawtmO+SwyOLjd5fIXiHG2yz
+35yY93l3V63/wmMhL8eS9r1qW5BzPqqbkWkc5yFhjDe9RxfUQ9cJcfdquQN0TkXQICdHJCH18JjU
+9A53VAbCccWH/wSQ93zoyxeZjpcnwabjVbO7vmIdZPOt0sAIrxDzhdoHWJVXH6OvRrfe7gzs9qoX
+YwDRaY2sDKPEWRTvKtXOy/U+jc9sK/6si6iNoPYTDn1l8e2sgyVbqVFdoWzYhvqzMZPTPMfFfqwI
+dpUeN4IWuP4sQoZgLUEztnhZ3t+XxIqCugy2mtoSXwup7ZtGjsmljtOp7Y8hj984YeN8jTcenBvf
+yIN1fvtqWKq8ybufe4sXm/XKG3O/ZTzlUpsX+Y/YSv96NZbmasVIPJY+vlViiaXHBHy7240l+d2v
+LH8kx1Jbu7FlYcAvnRPIwvbp6xaz93qwjf2SUlv51cWKopZG1dTx0W3lcD92qT+tfGZzA3FPfr3a
+3azelpSLSHwnN3jfWHs+O5YrD5Xtj/VtVsqWkl/Ll+Xn/U6l+viaqrOrxUJXjJWT5xrQSUcFY1np
+X33H0h8/92KpZhaG9tJ6xGFexhJ7gzT+vNeGttmPTzm0SJwMbn30fiNUFpX0flV9UqXiXr53CaO6
+kSqLrVG1sr16KK4/HB53NuK57zIMba1nGVo5s3ohDLijvNckcjD7OCTs7dJ4paOBqq4PrtSnh/Q+
+kxMuE9ZhvCjlgVQb3nA/ep/LTGuZJUg9NfGkPjODDWhZGiGNkUnmBsf6vEm7gvS9/hN+7nbg7fuK
+HeiT+nz8dO4OdLfwQ1zb/5F1ANXGov5YOjkiYN2A5tuHu3F3oBuxhDpg46o70DP2SVjg1lYjcbex
+DlbSxxkPoOJHor5yX3UHKtzfMTVm9dgBFKAQsAu1Vn6pcJE8cQPK1K5uKx5A84vxs8ti0QvoK7O7
++HANUNzGurCb2VnZb2TvXGf16Wc9rwE9W1lxoJdfH3ZaBCjQYqNKgCIUbVbv1Wfu4ASBJsdnNfso
+bB6XUwBU6I2R0o+NmidQsXO6MIzEHWANoHX1x3L8xgNorZnvruR5V6CD4jPvAEqgULB7Qu/xvucO
+dGMhMVgpLKtuQNXRKxtPJrYfn92AMjW5CrPvMdb84tLljbruDlS4f2Zqz3sXriNdqA3W45+5m0sT
+aCRuAbubHp14Al1R3ndOPUYay6mD/tkSAl0dQ+95DdbLdmEndgxgC33nWI8KpXsN6H0m4QCavzz6
+vKFAq0+fNdtIH3aYo8eqaAKFsVjGuvc9KHwunuddgR6vqm1PoDufL+WiB9DHJFDy5ZoycB3rwmHm
+6bClpIeuQC9fttc9gZ487R2UTKBAYzawZeZm5U5yB3q0OLp8b7QkV6A3R2zPE2gkfr2b2+14jfWQ
+uenzOx5At5M3P25fi65Ab7cbqyZQmBc72JeX4vDWA+iTwDyfXiXdgZ6cvv+8q2ysugGFeXkeZs89
+x/p1llq+8wJaY17OvzfcgZ7uJNXH4qBMgEbizrFWf2byHkClvdjtCXNEgdYXhrv2RbOtjm4fBQSa
+cgCNxAfS6eJ68sfo6wXAbqpOoK+rF0sa0E951SFplpnjE5EA5Va2Ent2oFl18H6wiEAzSGNOBnGU
+jT0t5msAdGcwxgqfejIFup2oph3ojRVrpysU6PNw7cAEGokDgpPXqfW9zQMEmxtnhddspnC0/BOA
+1kZOoGp7O6kBXTvP2ke6d12KL28QoJE4v319dGQb6+LjQGw8niFQZowrncjLC3fD830Ayo1xZ7XY
+6F6n4vyG46kmkVW1JK3cXx89Hbi+ParHNpj9p9TQ4+nKFlsfnC26PYUZqIE2HouXlir4fJwa9xrd
+fKG2xOJTJ9nA04++LsrcnnbVwunznkieusz+3nAosVsPBfe395djO6e31XOPp8P1w/2DxYHjqaHD
+HDLPR6mUOHJ/+zD/crKzNVrxeHr4drZWuMm4PpVOHtiIIUu59DinYpaMucyMP80vX9cfq1seTzcS
+N+WN2x3y1AVjR6XV2yW1XfJ4ey/9Us5fPbk/PS7Wfm4m+aTjqYGxk4uPn4OXasr97ZO7n1/8IMd5
+PP367mU+Fcn96f3zWSSev6hnPN5+Xn00qHv86cv3jc4PXZ7W77jNhXSh5oUx5e6kNlw4VdzffmOe
+P1Z+7i+4Po3fnrduErGTbXeMqermyzm/c55I4PPs2Jre5Er7p+elL3w6xoTU4svXIPa8UnF9Onpd
+Aym2Gt+IvXo830yu7tyu1s2nW/3kRp98Q47WJ0xqS95b+km4F5h4Z2XDNDMN73NT7tts6NXDdTaW
+rlzcxtI3Py7RuLyKJR6TI/x2BibmZzmWOXwBXejus0Bf29rsfUJvLncIPBNy7ljqrqA2vnk3IuYO
+MNe3DQPoYq692UiChrdQBXMnZ+eb6gK3snmW0YydpZ5VBG8t8sj+D76osdNYuvi0yn0CVgMqJJ+8
+gS7UfmQ8gTK1Uv7UAZRo4wQsKMZdfv3FA+j9Dx+guzHRG+jurnpvkfu8bazS3uJ3fvSkA93tWIFu
+xJ6tQIXLJSt6z3cuLEBby8ugj5lgU+ud6xMPoOIHUlvfHahwf+8NdKH2zthWJYK1IhhsBw+gYE2C
+7dDwAlp3AI3EbQhm1jyBEo3EEyjqI9de6E0TK8lzrPvLjlll06BrEPDkmzYRJ6OWf71IXKt5uqiE
+aXHhdDMWop46evmMm9xCo2Sbh8i6dOHtdCJV6g1OKPXDtzLqf/sEMTpmjRW/e3oBOD5Oax/bDHXf
+aLOveYiE9IV1PZ0tA3tceSxrfahflIg7aaufaF05GROAL+U+lEocPxYNALotpgHQ1yL057HCrpZ+
+1rAST5swnU1bW9W45QM4Y9lQ8h0+unPs5jepQvww2oDNLjMHYjxOPpAYbIaGNvBTYwSV1FaD37Mg
+0IL33esz+LkcJ/JltBrcqYFexb1LufbiWpp8UHzafZ6G9UqRfjQKRjr5uLDa5C7j22YPj8zx4VjG
+R6h91O8q5gy6zR+/fXN1HDR/6eNeJK6NkFhEDtcnHd/6qj+yQswfUDKdwd3L7mTI8iaG3Rsnsese
+El9yd0MW87byfedPWSZdEUr2pqweW19a2QuBeX+8Ez62npsZ8zqyGgM3vNN5CUSWg/Xcp7tO1lN9
+KvetAIzRY/OR+ASz8aPKVp8Hu0YTvDsCdw+XNaXMdVVWn06Hnv0hHUHensaPR6vTdQx3VbSgD22r
+0sq4XVdl0nNo/NL64VGIoUXijsHZhva06Ds0guhluoa8OsIo9ZdrzQc7Lo7MUSWXyajcif0+3beL
+CdcBRVxnyzagStZG58YytNE5o5xll+26umWaCJSn79kR87aWePCS0qDzG2RjyumUT2Pl7KNnY55N
+GRLZse4aXM+57uoLRyHG7LrqrDo/9KdeMyp5zGW6mqYf2lyxbtty5yilF8zptNGYY0LxQ+OCxInt
+Qhv1hWPWkzZyH73UJulSJG7r2dq3R8+4b670IB+4DzJdSrhoYSk7xhxT8in1HVMCb1+rvjIugPVY
+pNguIqbmIZjcdUYPWmzt2rkqZ7FeJ53fT2kUVnsytAu3PWOKrEbMH1k4vpx/l3D2P+UFz06Z/fFU
+6Wxd+lj0lpU75qoNFh67DpVuTLF4Ga346vy2GQxS6cLPnxoxhdXsjcECqFfdmorEJ28syO4Yb8rg
+li6N2Wl+NowF6XUTNGbntDNizM7RJsaY5tnSCI0r3d1n7IbrHi6Valjt2NSNI/Gx3g63AjiHRaF1
+XwXve45pcOFjpoLtrivsOS3xGVbl+x73PCodTmAoCz33mRxuxyPxmbETwuyLBGJn9+wrrBvBYyxb
+A9STPdhC+GkaN/EcHYmE6UoQFwjsiItuORVOPJe9MS8O27DBJ11FVOnuRZjMMqRbmoZu2bcFOK2R
+LfILa0BRojKcDIDdqWHRYfbRxN2dgH14LBAww5wS3mrxheiUtUsTMABr1M34kvu5Px8GgBwmUV2e
+BemW8W2vnR+7jQ/0sQmRXhkGaQoOmgVNPjIeRIdU+zz4YOc0vq3d+76uW4bzdXrZ5A==
+	]]>
+	<![CDATA[
+	P/eZN3bh3pMYIvGJkOW/xN2QRVqx775pyBJnQJZ9gW8OyQK3ycpt9mAUwuoO9i4dOBa4p4fEz5cA
+evKSf28c+rsRozhOaPzSGjoKgoziEC7ZA8SYXYOfamgJ/6FFQjg4DsbE8qTuDbL2vw4YZfB5O+OA
+DkaePrqIleP5+n34JflbCEGBbmixyBdEzIs6iQ/Ey18DuLH7a7wo2cIKbJ4GuyqNocmMXZU+dKrS
+hockSJkem4O188WJcGfRYE+t/fHek3LXhD1w1z8kYpDKSj/nZrAmDEObw3o5dMrAiekcMbZ2HrOL
+v9DeaAudb1/Hec8BReL+lG6jnXtvH7s/AzBprH/olHdTMABAi5uzkEQOe4k6D10WsVOYSA6hJa5r
+s+OiLplI2eM3YFR3l27rzn/VeXkVgAlPuT9hGZVSf8k4dkWD5J2ntMPGcuHWS7C/FRtjZufJZcDo
+zmhGXzyZtTGR57rHF9yO3ZAM7I3bnjhpZ+oVaGtFsyUNfWzadkLJPYxUCZB8pDH7DuFEQlRIX9ii
+bXGb12lSYtnMOwwGh8HGbHbX1OKG9NW+6RNmj88TlVchUan5Li4c9rkLR1t14WjXYTlaJDBCA9bG
+zBwNMAZqZQAbCs/RBp+umz7Eaz3hDhI2xs2uKWGu1uXCrGv/2uRoM63967AcTacxn3Zm52jX89l7
+Jb158dw620EaG17nNCoa92yNT9g642lBm1uHDh3F6rvQBJzWlRUwgLdWHUFd/oEPE8Vc3d04PWVT
+bMnDdJpMlsrK6TdysbFgJhsJyWbv+2GjH9zYjL7231amNhpts1ZJheMwge1kJu+NTVbq7cwcAkFa
+sbBgv533wHa8V45DJdfz+DyXITQ2odfPRRYant7XZNpFGt5Ort977SMDH5tdvwcLyztqIRKfTBpC
+Y97mo6csdPfBYmNzWD71BWVpdil2G9alFSDFbifX791aIbM/uzS89ZeFlli44HZ8pKG/LBznMPWF
+Y25yaegpCzEkPE0jIizScCz2ZYJwJPvo70xZqK99r+ApMwzDkwlBv354mqMUlZHxBenhsUBjIUCj
+9FzbY35+bCzUggyh6UJTYpBXwZfX2jHWjfvPZCSkWxXnMtQ6d909NS2+F9XPde0TTufRJesitfgt
+wywvFyMt6yKW7h1iKYQ/2dNIawx8xJItci2MvX/vjKWfeHFZvT1c6e7T3zYKG22LTX0vec/LRLs3
+2NgwgIhDe0juQ/mTvXYG7JTcGJDw25CNeagY5WzOLfjWgGKliZxnpyxd8nELjy0uOi9OH5C5LPAb
+DQp3gWfNlktcLBXwZJZLzIw7imWkzIuZQYen0Mwjh84/g87IGJoxh84/g86y9zpTDl3KN4POyBac
+MYfOAOqaQWdGDs+WQ+efQWdmC86WQ+cJlGTQeWYLTphD559BZ80WnCWHzj+DzpHDO3UOnX8GHZFi
+c8ihS/lm0BEoc8ihc2FRlgw6EqU2WQ6dPSDZOw+o77DE3c1eq17nnYG14x97RrsU7Ok9W1aDArc3
+Gwl/5ZxEETxWguJcwrqYzpZdI0Kn8fQCns4miSX33uM7W/GOJQ+LJ5pXNpZlMx5pthoiGQx9mSn/
+Lrns8fk0lp5yfI6ckeDMufDjywatl9BId2TweHUpTOZjgBvMp0s6r9H15ImT5sLzmvu06ogcniaB
+KkQoCJFiIYJBflRn2ZuzR3TfZxZmH5qL6u4SdROY7DZ5KMiYvT+lx3hsrmyOKm8rKTDZbYJQEC9u
+CYjx2dedyAyBpoDGwmVouTdmD8ECm3U3ZVchasQm9818DMmz6gt3/iEOi5ZsQX+zt+ZIMg3efk56
+8uR6zT+FcRLHWc3cy3b19NrcJB6OM7vjMDXuJmntmpkCOrecPrfGO7HfmpUWLg/sceivTkySx+d/
+dEHoOLvWrkPzcsvjO+6ZTivv1LSt4faBR5fGVGn/GHjolHcMvDF1wfNH8/iWgmRu6Dy+rmuEuCXn
+Paxbajc4J8bZFLFfPBsLOAUhdL/InkVAkswkg7Rvf8yIsYCMmckw5r0VMgXG3A9DCNmY3fFbUMcC
+nUj20zwMiPc9/9SliHWxezYRlLYY1IDFO+rVxBVLPwK483Dbe23b4mCDjb0x166PsedxRgRXul9Y
+nrwJWx9eskHWqznTHjjZGgQlynnMkKnBvu85d0a8zTDvXLvgtR+MDu8tRn9kGF7rwCw5h3jz0lz2
+3Fa5M3Z0MaweyT0PGlm7HrnvmRVr5Fg59EgvSn4edCdxW2im0nh2rUuCnC/X8c6IckYQTa2PQZfC
+pLRGQq3452Ei7HJ1jUPSaQw6tTIfPDl3cZAE7HZlaBIIyoxzdMkzHxnT2SbyyPh0iZ9Mivll2Pl5
+ZPQzu8J1KiApzrNL42d3bLMHA4dHhl+S+wE2nb9HxqAx9nBmt8WBp0fGwmFCmg1fB5N7ZDzsfRja
+yuxDMzwybtEd4dPQwnpkfM5TwjS0yQKE3edqLCN1Co8MZqAFemQiYRATFGkfmJyj6TCInfxkaaI+
+URI7I4eyrOVYBUXThFGW+4fzyEncvmb9J9HbNnDGXB3O4tRxDM2MnPWK6Q0ztM1kWPr0lC/9w1Ch
+C4HpYyR0IThbMCivLkzoVCQ4r27m2PU+Zj76uN1CBYhYkuu8XKB2Sg4XqgeQF1cc+6hQlvCOyDIi
+u0JsPkyfD2c7vcHIiJt3Ptxs54+FzYcLoLE55cMR38VsSeAh8uFCR6jOlA9n6snWjLgZRzWWDxdw
+Iuic8uG8o6HmmQ9nucnINYltPvlwhMbGMuLmnQ/nOi9zz4fztcU8tnXQkzLZBp1nvljNn4BCx0SS
+I4bD6JZhYiLHoiSmW/vXs6TXm5GQN73Z1Qnaynhk8MQ7vNiOw3gO7o3LKWeknVlz7Gkr+iI0818s
+mzQTRTxf+7q9HTHwoSKeXbbyMIXNPxGHZqSGWIYwETNlRFG/ZXl+BwFjUzfOlRPIxzyXYfXpPnQ6
+qac2Dvie9ZQLIsPnchowaSfwbJlA65W0M/EydJNi2M7syxBb8ZCFnqdpeYZZY2P2I4GDTkNb+/Y5
+rRHHl3L4sLAsUJUeN6hdM1Jv55GR+vQ9x4xUaGx+GalP33PJSGUXxFn9RyQ/K+3WyqQZqdDOFHzT
+NV8sIJ0/ZG+YcLZYYDthjoG2x/V55m/BAvE5NDVckJE16gYZRHpsGa4lAiYibLStNRlu1oge11Q4
+ixQLE9FjH2ToVLigs6DnkwpnrEo9GW46v2VAKty0duVkqXCeZxDNNRUu4PSGOaXC0fP6AlTDUIph
+OeuXW21jBsEnwmNenS1AIsyJ8N762P3cDlQjGJuXAxmz1zyOMZxch2kM7IcMh9lc8MpGL2dzobZw
+fEIXMMtP89G5572GSG52dMmfIowoaP/YAc0DdE5vjXMlZ9u16IW3x7dC5aF2c7mTG5aOIvGq+mPz
+ZfOq8smWS7mD28qicnBZ2U5dXm32XlN5+LZ7BjVXyrW7p1qLW9laqFBhRNy9Fn/yzXgCmHSyrZ9z
+pXXFnuy2eHN/ZnVf2VLAttbKj/deyW53Phl2eDcfax2/I9mNWT32AJpfxEu1n72uiwvIsOvz3kDx
+Wm1PoHip9rsjF8tyH1/SJ9ntTOQsQO15Z+SqaQOo87o4vB6z45VhJyR9MuwWavWsJ1Cmdrhx5gBq
+vY8vLpxUXr2S3V78kt2W8t5Ad88XH3zu44ufto/rXkAvfNB7cnjjAGrNsGOq1euafVaXyIEFxjct
+E2+0upkLVY8vM7aYXq+azOvqWjFEi6m13rBqik4Y871gKqJGFIG+heMiUMt+MfeBIbdODRbQKibt
+e0SVoGP/w8lrsvY3XUPLvL0m3vdYeRwl7hVz5Z3aUw6IJ3Xb/HLx9c14k5ytS9o9cuP3ik7qXXLe
+JOc2daG8cGOHnk2aDWl4es+We0zAOeL2uD6fq8zGgqcDvXCTXCLnOb7Ae9+CLhsJNb4wdw2ETUHt
+hbhnJCzSg0KmQ6+XXtB5+W7hrn4X0GkW3xyz6Wb3w4TJpnOzA9y8cLNl09mGpuXSBZ0PM3k2nZtP
+ULtjyAvLU2TTObkT5tLNJfMxcBs7MvdsOi+v9Xyz6dwCSSY4ISRkNp2vXTm3bDq3fRrXvdeZsunc
+cuk8d0amzqZz87PYz7ecRzadZ87IXLPpQp1zNXM2nVHZkkvntis6WzadmzCKxOedTefWJXO3el7Z
+dG65dGM35sycTec2f9p6mWM2nVtTdId3ntl0burgWM7IzNl0U2Jswmw6f4zNK5suVJbNzNl04XOs
+Zsmmc9M8HbnVc8imc2M49nsT5pFN57ZbgjQ232w6awN6Lp239TptNp3bPHvtjEyfTWfOkLm14i1f
+ps2mc0OGx21ZM2TTueXSeWZyTZ1N5zYgUxv3UkqxU7MagGRnpKI6L959HrwHqBj+CWJGeljMYSVN
+nfgUgltYtYv53Ffnr13M6746t9vqXLSLcHgKvNnWSqTEo+h5L1yQYhGOBCpDhBJwE61t5fheVefZ
+JbdIe59OhZY+9i45ozv2Q2gAYbtkWpjhOIwPnpQwq3csk8tuEbnsPX8d2EWCS/TRmBPM1a50XnQ3
+Vc6a9Zo793iYsCp52GvuIiE8xgczX3NHb8oLuLgrXCKdT4BE2Pjk2a65M7M4fS66m/mau8k8itNe
+c+fmURy76G6yXKXy+DV3zpPAXS+6m3zziN++TlnuYp/ynKv+4dzyLLbXzkMlvwZnFkXiMLi1xMx5
+Z/6xGJFQFLp9HfcOqQkda304j2P48Xo6j9hfe6RKcIahdxBH2Kw0RMwsya/2JEOrAu1Nyd43bFk3
+QIBHjucTQZld0AWdDeW134PpatnQM+kdDXU5v2ioy3lGQ12GjIYKCGw++woVCBWc+ZiceSuEtOI4
+Dtxl9kO2M4nI84jsIu1MtwIdrVgy7KbNZbc05n22YIgb2J2JtS4HFEPZpr+UDn8qIDZW9k9e8Y4I
+GIvohsa4UJHhFtnlicqfyipB5UT3vfooEaitJZ0R1FCWCtqvDOf6w+ynQNU9RGbKTW8iTcJNj7Dm
+vs3tBsObniORYbq1P/gMddFQcObj+uqsdkDZPKV4pt1q0k6YfM6gDG7HEcVT9ob4LtbtiRUTXsTj
+WCBuiQxT7/Ci7rU6lsiw8h2YmRJyGU5xw51bfuW93xb5VDfczePe6uAb7kJp4zPfcGdmPrrfcTfZ
+8vE6r3iKm/Lmkpdkv+NuhlE585Imu5ZuihvuIiEPyZnuhruwp5pjkMrsCCR3cE8TsOGKwPrCi2su
+rOXswfCJtfWFxuJERqhH5uMcEmufvs3s9unPuaLthPNm+cZcYTuzJtaSVvCsm9kTa7E33ufCnZ5b
+9OQQaUy3IfLb3ZKYLDqMYxlmXJbh3ZR+Ldd737wPlpk0ielFJbaWlxTzSGPyQuWdv9lOz+sLa7jf
+TWm2u67Ku1Bu6jBJTC8qsd3nYVdioqe/AW+3K73SmFY2b7wZcwjF0OZVwE6FTGwLpw==
+	]]>
+	<![CDATA[
+	GJazGaIY2qGUs4F3fodSDO8diqHjprxJc1xLdx+eZ5xYWIH9HHifjLAAs8h/x8aJsVDJ4iGOpoKm
+8g4dZvocV+dZyB7OyZB3C05/3aMRB0suyZtXjuu9W4arV9azn45mrl4mV3vJuMHT08yUsqpus7D2
+aZLe1XbhvvJQu7+qPFTVneJe/uqgXMo2y+VS7hDDOC/7uuCJd+wY07xLjnvYrvudR2ueuP2isEfv
+y9+k87UzKynZ8uFS681TryQ88SMSX41vxHpeaXiuuX96alor5wmUqV2Vzm32i+MeNmuWmBPoq981
+dxnZAtSemhaJq4O11MAA60xNE+4+jtY97mFbSHimpqmjV9aShKfdlWZB8Mb614UH0PwiuV3PKx/u
+0RNoJA4I/vJOOGRqvasrT6DLR8pHywuoYgKlstKehnd+5w20evK464le2+WFVqAwLwD2fGxWYWlq
+4Mk3jc7XQtZbd9TTOP9YTeHpKFSLQvKM1tPE5FHeRek8MbIFa6OO06vi5yfecZN2nmGTxG+ZGj9f
+7my5FzZ+zE82P1acZ3UGhwx5pyR9+3cpEr5TE4XC2De6LJy/MnNoldklR2CVlw82hCfpbCUWduro
+vHjjaaLQKv+stIlCq3yy0jwjNO2nm4aip95kUVqesT2VSUI2g7rksMVmSHUMitKiZxGESgX0PvBm
+wvXiE6e1Q3szbufYTetsb4xZkZu/5mFK/Kj6b1+G8sHOfGqcBWPVue1b/6jOYZcHhvY0u3/sR3UO
+5zbCnJurd+pzrSfyLKN31DsLcOZDaDEHMGy+WKDVgo15R2mF8Y85gkYaXM95A2V94ch/zGE5TIMb
+zctG9nQHT+wMrjk4qDPqZrLDrvAQMu/DrkwHjZ5hF+xVoSdD2AIIdoNPXaD6iMUS985u8xGO4RLJ
+jJ3ET2k4n3MOxs4fmy3HKkh5s3hj6QlUXp1SPM85CKGN2+8Xc/D7iVMBzfmz83vX/P3QqYCBd7mM
+z59HZsrK5k1mbsRwkw2+ZSZ8Y94765H4xI0FXv47CcYC7/cJ3y9unhjj54kxwbOxsXRh+w7vtFmA
+YbVD611pk2cBhs0BHD9Vw6uJWW7Us2t9k2YBhs0BpJx/2izAYBvK437kibIA3VndeA6gXxys1wxN
+fqOeM1ZhsizAsDmAPjlWnuiY/EY9Vxs5dBZg2BxALxtZ68/YqBzaU8hL+aa8kW3CS/m8bsua76V8
+/l6FeV3KFwnPNGa4lM+2Kn/bpXzEOzrtDXihL+Wj8+J3A948LuUDnR+v5ZsTnryCLya/v3KaS/nc
+vArYqSPhyUt3vg5zNpT9Vj/zFrPZ7vUzsvdcb/WbOJNrbmdDTXOvn9fQVmaPtj2Yx9lQk9zr55t1
+59STp0xHnMPZUKHu9QuRXzmHe/0M7LgmNo1R8pT3+vnf6heJh1DZdez43Os3USbX1Pf62SnCeauf
+I1Jl6nv9/Ifmd3/lJPf6eXZkHjeAGPf6+Q8oEiIdcaYAaDJNAaeaT5CO6HcRViQeOubM914//9Wr
+aeMz3+vnL+jsVtL09/pZ5srlVr+pT6By3OvnTRZUgw0Ingp5r19QFPR87vWbT8570L1+/q047uOb
++l4/Wyt+MVcz3evnGU5G9kB8M1InuNfPf0NFvylvLA93wnv9/NJTLruo888pS8znVj9H3uvU9/r5
+79OQrIE53OvnYzndZxJeGamT3uvnml1g3OpncMsZ8h6MI58DdMvZ7/ULvfZnutfPTEd02x2e6j6+
+iU/x8LqPb/a8B+utfrNkc1jv9XOxci1bxGGibcPc6+cf2Gr3wU5/r5//eR7GvTwz3uunp1y5x2dY
+MoZmutcvkI/N5V4/rzmlt/rN5T6+wCCNcPfxzXCYjhnRPYd7/VK+t/pNdHrD+L1+wVfxeXKYae71
+80m2YBdSaFfO414/F/Ky3Oo3W1ZaWDXH9MPMdq+fv5pjZtbPdq+fgW3XRI0p7uNzzZ6eNO91unv9
+XFoJeTf6JPf6+bfiHXPlcq/f1MnwNCdx9nv9/G/1QyjzuNdvy/dWP8LH5nCvn3+gE87+PO718zfb
+KcZmv9fP6Fe4VTnlvX7T2pWT3evnwQO1W/3mEz1IuuRzq5/9tPnp7/XzVwwj8fnc6+efEOsmkae5
+188LlfRWP199bIJ7/fzjgQ2P4oz3+k2uw0xzr5/XTNJb/UJm1wbe6xci3nIO9/r5CwfDA2+KhyMh
+O6ajHQk+XaZyYTziw3TsUh1mhV+SP3MO167vHmZA4L09bdHBx4T0hd2HtWxb9okvawwxYczGhSAk
+TUBPgZKszm5nBBFmhMUSj8lRLJNbOc7yR/KSXv1ooKrcoBhbfVfPc5n42jJ/eywWxXxq8LGf643q
+K3uKJK9uPy49LMT2h8lYsXaRW7j/kV9burzpFSPx+Gf38mhF+ehn8pdH3y+Fz9bR+87n68nHoXIp
+yydPe983l2z/8O3y47zdud7NHY9uXnaTiZeXcir58178efp1llp/66cedoZq/DKxoqr8Umyhp/Ry
+cWbpYz35cNS8AYzJqePE1vfS1xHTincrqrq9dhZbfd49jnGl005qvSnsMDVme4upXd3WmN3F3gmz
+e3ryoart7Yw6+thaGaykTxo48JiWabn1XU1tSiePOCUxkvQGGKveFF7UwfvBIpM7VVwZkjYvJL90
+azCsPNSKR7XN4mbTvAKS3iO4Uvq+cCCLoCoSX1E6rHD5cb30re508yex25PDlDlW50hHr9ml1eX4
+3dmStN4pxc8udw9WXi/3NwV5+TifMpJDYZqeqpnC0fJPIItUjeQk7mdiavs5hwmcFyBaTlW7slW2
+Lp/XeMdKaESd0PytJXNopvQx5D7NtC2srC33OKF6W/q+2ckNVyspWWjkSlVubwfKjg923q6vTop7
++deTlCxubtfkpYtW+flgcY+MlCvdp6p0WZND3bZ2bxO4v5JIVdLxUSReS+zt77PVH2sb5XY9x+Lk
+dKvNz2+Zyd19ZriXvVaaydW/MyjjlzAiIoNvg8Dc7H3y29cLWbJZo3P2xRViCjE5UUiSn4CxnR6u
+F3EtRQpgOV98w8+dDP35PFDS5Bu/tLHxWntJPh4ybz923nfWj2Iq9PuQdpR2M810X40Hq9YH5Xgj
+Ejcepa2PrtmW8SBrffC++WY8YCwPMkv7H/qDkyQZKbt7tFAnZURWnqQs1Xd/ZJtG9Yz1QX+NwbKc
+JhLEEwYTlr7YvfwRhz852nbjR7yuN3CeIlUicbbRZ/GcjvOMwXyWgFgSeD/MeZa208yXsZ1zhhwa
+zzb3TslPrdnmwyNLzBQmd19L5Y4vP3l4epUmT7lkfq1lYuwqS6EwySWJ4TqX8WpaTv7YWWdulqxL
+E1gmZajEwhy3XjXOD+3lzPZg9ufRImPpIZtbHGykrtfV/Na1cFIsPLcS1K4sccmHy5hGv/ePXPGr
+dzQoHt7evprkxSVHrU994LcWUuEqe5uoCd5S6uYqD/ssJftK81Qk3yJxrtK55rTS0eMPsti5arL+
+on3j3kVsQqRNvDzsYIsPWZKjwr10wHQn776MLrS2X5N3BrU9cNZVyb2ut34aj4RU9eZuD8fSsIzl
+9TZWRr6yjocVX5Q62ffV4lnz7ahyuB+7NF01jH6gY9nw0S3bPPA6Oy7x8dG+ogN9ztF1vsxdC6S3
+/PL6o6h9q9TbRj1eq3fzVXT0JhIvnpavnmuVzkKzeHH1tFJtZHZuTQ2BinK7+g39Pisb0nfNIX2d
+snf1uQYYi6U/ft7F0jc/qrH08e1dLHnykECJfBBLjUCegZ67F0snt69iyXZnK5bpnj/FUs2sbJPX
+oB8QfyqxtXKb9wkyUmBhRcIyV40oaPGyr1UCzgg/78G+ORMSTG6YwOl+Gdaq3LEE3/ZWMCb0G4+V
+ROfzXpIsXHQWkp/wcd/LanxxJ/ZM5hTtynI2TVJouOfRxn6ufTfM0nlrp9dSRFPil9arB24WJmi6
+J4d02Rsf+OBaiz7fKiTJooB5AVJ6ZleLBWDXW5spvcuHlEEg38SxHAIJFG72yq+fxRZXerje1sTE
+1hHDiI1DJK9D1sr0St95mJz3U2RwBGPaCDGz/qmoqWq75TQtqy/s9+HnPq0CivH9z1JnoVtj9zI1
+Fpuwtr23fcG76XeW/f1li1a4JT4NTB113Hn59cglQY/gXr74g9Q2l+bYXfaxxjbeU/dE+JM32NVS
+q6J5exzuHxbodZt7XT1c4xLvF6tu6inDJLLrhi57YvPcEO1wmEdKlZEWd/CjhJTM1U5oQXLjZA1p
+eh8p+SKWOl9YxqeXsUyR38KPFhD73V4sqarpWDr2uoJC+8ZJzsrZZgrJOU4POKg+1fCcK6hZMNbq
+TrX+Wv3c6X7nXnduVi7ui1frPxOV/cf8QfFylFjY2diuZQ0F7Js0S672zn3Ee2m7wWUBSm6UtoJ1
+AC23a8sqwLv73untqfe1l/TeYvH0feOoeFURlipv54MLogQNYs8rFU053XxYBADHXeTJ287oDu8B
+2yGfV96W+4trfLnSgIE3X0IMNxLXB9xVocVLwWnY4aIBNsut0IMitEMhjrt4AXHGIruYQaVbOj3b
+AZYoiq8OyCCRfVBNID/J00Lmmi+rO+tPHy+ReCV78aqW3za7jYmQzhfVWMVzun8TjW1dv6xWHaYC
+jRACnSGl3fStHbMBJmDKOHGGL0m8lF9cO7rYWasq7dJnInFe3TtrszvfxVyxsv/VHoBYYkvaWhQq
+beAmF0NclStZYa/4Zc6zzWs9Mb7DYht3RjQLDI8JkRdSW6PlmOfQpxw4zH6ooc9GaKhbTjB058C3
+17eWrVwe5ayjN4Yl7s5ILWx0dWVxI5b+7h8hGz1CXeAQHmRUZJ6XoBXsAKddLaVjGSnzw64fMFh5
+G9Y+URMsRxbNY7E7KF7zws2NzdwoOzeHm/u1l+FVrPqaP/0gM4D6WPBin5W3gQYbPOCZeZvO+X0H
+7DZc4uOAOZVGmgr5PhhLCzIgkzzxOU0yMLObpYrbWhvPS/odbCYSn5mth5Dh4WjMLsUnhxyJ/xal
+JUiKzaK0eCKanNEdNOBJhutCaKUVp298pkn2XFeEW9pW1ow05qqtoRSbhq+gWXDzbUa5OMwC8lq5
+lGW46m3p/gQoOd1ndorN85NaZTslHhTTvbWVykNt+Ew8bjtvV/31qvrcOBU7jR9LlVH97HQnpw6X
+Sq8n3GVNXhS3TH/c+uh9K13KCuoNt7K9umt6B+luQkI/fyy3hCue+nh0/+ArmGb5xUE11X74KF7d
+3Krriqx+wuhjH4XvvYujar2+kq0+tBY+CN4tMxDvPZdRP+CAj5Xu2X3bqOmJfMGQl5ZAk/h+wjkA
+9Jd/PHnqUeSUM1OdGJxop45NAfSWq2SzG7fAz5/ZnfWDz4uwOgwBalciptKeQIeZWnEML8pIzFUo
+2R1Oe3LHdiQ+C77Djnl6KTaJEI3EPcXoHNUl0GHmoj/4Q0bv6AQC3BVyMH+dlyWO2w==
+	]]>
+	<![CDATA[
+	EWcW0wx3GEy8T2UlTai3Fc6sejJ24HGOUsXbEt/bWis/HugLbfPCiXTi/S3dtUY+m1rb74W157Nj
+GURHHg9K3ShF4iAoFk9IwcZGZrgBEmT3CETP5dFObrh9WNwTr7Mgbm4u4SdTW1vuVdYqi60881vk
+y5QMQGO3OC+/wVwNIV9mNZT75XLpc6X7VMkWVgZEsILcDyla//+VL9NItkg8xIA9hwscpr8UwhlD
+c9/mNMmEqWe6Ganj8AugfJleqK8fLlWeKru7m5/AV/hvz4EDFC8lanoVamxxgf0y0ZxPR+KR+PRu
+sPCQjVOawy2vKRdXJD5vbuLBx2ZSHMMNV6OxsMtryjEDh5lkeU05cI3Gwi6vEIsLd6zurSFPrlE3
+6coFhy69k1jqIbETS3WEWiz90jrAnyu4IfiMPrwT3DdZR+feaSz5+iZpm4QvLT6WOZDvHa6/SNzh
+/JvW9eer1YF8mbO33U2hg9mfs58ijIdkis0Vk/Y9mexvtZENLRooec5+CreBa3tJv8GIsdpQSGNT
+uSKn98FOvOPhrU9P4R+bxjNngzytf2wiikfr1d+U+I0+WH/7zfSP0Uijqfxj3b5au9oW7ohJUpMX
+RoWJbBW3VY66pXOdryTK7dhjMuwSp+KN3lPQzt/SWCHdXDOznkMuNHZFGZY/Cs9KSN72TVrBb6Ap
+3T5eLV/SwBYaMj6xoN++WH0qXl3//BHSSiLfaCjmepp6iIgTlJ6FPSG1FWsvn53VWrFT/+njITHX
+GPlGAicHsc1nPVa3/p0Lq0Xj/stvnXgy7eS0k9858WTakcP81oknk01k5e+c+FC7PDNPPJl2Yr3+
+zokPt8c368STaSfRUL9z4sm0G2v/d018kAbrP/Gaaj/cToWIljZONjYC8+nGjTaCpI2U2L51aj/l
+VSPMGs2ZI9EZPaj/TGgeRTMAkUi51OZltaUrxk1b6gCRpBuHt6Yk5cpXDcHsJinDO2+O9QZe4/Zs
+dGxi1Dj7tmihyw/cgWUEpCy2ef9l2KfXthtcyJzfW53By2KvZvPBklJ+/9Fs4tJ+uQsNU9WCAGsv
+K1zyq1TAGPAEu/vjnUE6SGpl9e9VrewTc3jxjErRCEltjRlINL5+jU0ZYfSrO7erdUIWGHiPYZNn
+PRrPn9h+7FgWBYlVpTcZkUuFjJtpni1rer1zfYIdXcAH9/arbRLmvNzFerkqvb9ILd0/GqvyI9FY
+unhi6wvCLqwX+9VG+j0OBGOjmJnZEBMGj8v6ukripVDyotkbK/GRA+kpCnZ4zUNCkRDfiL3qSBBy
+JhKwP5/OA9Qp96oMLg0UPFlRMHo8NVBAr6iyxMKlQyCB3zlPJAgS1FF9+9SGgrWBLkQo0Jh5yxPK
+l2Ak0PMKCfWXkocGHew9Zxd+XoegA7DFgPkwGhEXTj81JHAj1oqE5umxFx1oB0nRfnPv526EBBjz
+b8KgRs8m/BtASZLUvD3TNlF92lo10e+5HnBevJqoL+ymZumDSZC4KqdronR3nwkxDNIAkWLjTZCT
+cWcYBs0/M0iK7ItNSFSTUyWJiLDyJytdTrC6LQ1YqFJvgGIsdBOELmfiMAkrXVqbCDsbCStV2hqg
+EXduvXA2YdKl92xsr3129QZWLXNBPYoJK11OQ1QJf6rU175vEyZd+qDST+RZuSWzV7lsGBfdde01
+kybxkesJjXrPznrhaMxnVEkrjU2AWQuNJb1oLCydJ00acxCIncb8hmEVxpMSCKWxpJXGphqGSWNu
+dB6GxpJeNBa6D6Ekcmyl8nSuNcENftibWA3B+VAi+/Ri1aTLKftgl8jTYGLVSpV+FOEtkVc96TIE
+4yINTC+Ricml/FRymmlmTZG2ZTVnXuuxxHbnIpZUv3uReCz5qqTsGVNjKVlW4wSNUM2Q5GjiU2s5
+t0yzT7VEquOulkh1qqzqGXYrm5eETpLU7ahlDG2usnuFWJXd/Vg9MEzKtJm4Bm3XRpbMG3gqeWTe
+mPfy6I6CJZquZ+bKaob51Qr3Wj0/wdXLaSmK4tOAbfy4TmFqT46m8CW3d9YNa7kkDs+WlN3nh8bP
+SLzUkRYlRMIiEmIdd52uYum6mLVgzLhD05G15Tiohsnd37F6ktYtA705XyaJcpaYq3EkiNkV0zxG
+K79DkiNdjGKr31m3068N3K3TtX+aP1eWtjRkPfB7pouicFLf3tT8OdZz2g6Yt7X3HTb9PqjhPRwF
+5i1RK3HJ/SVWT9K67OOCzFruFaVOdeKx0G1y4gG6IajMjD+ocCTBOHd8+c0zSmNzi7BbIKSXLNtc
++to10h/JeSULuJvQEArMwVltSyPExnOG3b3+qmhxPLahrT9/vRyYidrIRhmKgpXtoy2SD0eRb00u
+O7qMxNnU536NbV7kRS0/jw7Y0Xkxo2XAko4sbsRzH714gUtmhDy+tsUXXx/W2cbRNWKxz+K83JF7
+3filtUSBnHXT6LN7SzsiDLgBBvfn91A74HZsCYg4UoY5rGhriJ66QI4D110CG3TWlM+azCVbe2fA
+pxoi5r41Nne4ZGFpF1PlWBxahauunqzxyzx/kGun92uY3vqcwvRHklzHKMOdTVg+t6f0jV32rsqm
+r784fKOUa+9e7OHRjjzzdt0q8su3zyf6aVrAmr60HF5RSJqzSqYRWO9x2pjVpOEwsp4HQceiOX+c
+D/RdHgRFcxK9suNnyY3H9RIuO36W3HjAWMjs+Fly421QfLPjUzPkxmu7PCGy42fJjdd2eUJkx8+S
+G+9636trdvwsufE6JQdnx8+SG69nowdnx8+SGw9yP2R2/Cy58ZF42Oz4WXLjYe2HzI73zo1H1ci+
+R7JCs9FXixLxayXNbPSznqZE3X2mKNpKdz8G6KjN5toLZ8sgsb6GqK8MdK6apc4YctggYUdEJzbZ
+EaY2g2gU9/AMIh23T/DODa7aPSKsd/CuhSw5TBHXOZ43uZfzOFl0j3FB7wVhYSRBHm/8tHMvmoNe
+jve1Lm/tEFaY0Hjk1n7OSD+3Ma5+makcbPQYqHLKGiT+g9HuS7Iok3SEwK5w5ZD5xWFkKKeibK2/
+ltOYlJYCrwBPbgFmdy8sbQOjj2lhv73/sxUpSFI+KomSFM1djDqKeqq239vdaDqyHskV91n2utvq
+1VRFuVL+GVZ6zdGX0h1G16K54mV5f18SK0qz11KiabrxVbD4c2nfNeWK91LBqRJaeZN3P/cWLzbr
+lTfmfsup2Sf5vU2SUw5KPSgMGzR3Mv3R/sAQqSyemXCJ2ZGVWIY55shZCJ4n9tAdqof818NG5rXW
+K9zyTMvKxkjamapubTaK6f7Jwc6hPNiS9jZus7Xeg3BTVZ8emMpD7f6KHPVDtiLGDy48kqc6BCKR
+qS/g+A7wYx0T5s9g1Ms/XA6BGE8iH+5IxGltTrTtyJz60tcT5TMrm/eivuxeCJVmTFsBfxpCDo+D
+0L4lqN6vDD7xcPA9SvB40GNaX3a0oJzN0hWnv5gz1yO/fdMv6ecxCAmjo89MK5FY0x+srZoPrMoM
+rChgh8YjU5mFR7Ws5cHz6MeOeeqD+cAKfnctSU02C+TdnZTlqIkfVti7tYyJVkDgtQplRzmNje2e
+MsiPUpRv5XavOXL8BrNXH8paA2flFFZJa1tXZ/sZ4/oFPBOOLpWzoyypBADuYNGeXTDoRWG1NXx2
+R5uF9dLNaobcUjapKwX7ZCYBSpld14Den2Y1KNQuUH4k38of+dqpZuZ5mXTOYzosJt1Fzq09w3Cc
+osVrxrIqrzfXysXr5fXX8kfhsF+8KnZvyWriSo+rPzB8g8j85p0hq654g7xerfPbOEobE1YHsZEF
+1aRxQdTbNN5TnaTf6gs3RHdNG0Y8HvWN5hTZ9iXHmZBv2tQ23kWyXjQh93mdRbcIawi5jHH4SgYW
+XHlT681n3dReGuRUkkhcf/Qu6Ebyg2hRC7ava3u6xfWQqeTqG8tr792V69pGVfhpOve1jeDdu3Pt
+lGD6oZ1YaF5UdbRhpcbhY45o/tDv4ir9Vn06SNFvln4P33lSpjsarL3JP3ztdSpv8cEVST25E4qH
+d8yilet6HGdnmpWeh53QYK98vDwCTqvcVRZboypg7Hn34m7t+bSXIOeIlZId9WwnN8zvlapM9mr9
+4ai7tdu5uXsq7uVjDTMiwVMhcVNH6CFD81RI3NQRejj6PBUSN3UElZT5KiRu6ojm/J6TQuIVYmG9
+nFb3HNmPKR5Tjk8s4nap+kM0YgrObY5JeuhhhoQl6EHuy03pcCyyYZgYGE2cjUc2rO6SiFQ9fqK3
+Oh6AkaHXOWjhtFxCvudtIRj5xVi8tFTxieEo5Y7NbXK2drfLmkfzaVwOVR8aGpxrb11XCX3jOUxb
+ZEXoZTffetm9mmufdlOmHUJOZLKtHPdddbKnTjdY/EILiCCgoQWbnEd0BTm5yX1X3er8nm5XPRk2
+uoJcioKhBc7oCvREakj4YUUC8WFrgQUPVhRAb2yhPVLfjK7QDoCZLLrC2I0J63t3buFmDCRoQAkS
+tCkZCzEZR8Hm0C3ABDTYsCEm22tnwymjK7TrSvAKhZWZAnWUn0rCswGY/TBNDD6Ts/QBD0tb+V6d
+ZUWQSwn8+0BChPyGQQ9UnwGVoOdn9ON/ph0GObU3sA+RuE8T12u5WUJ20DvJkAaQj03VBJte+Ug4
+Yqc817YWVOVY3Si7k2GbcG9AHq7OxmFQU0i59sGLIiLxMUwcpdKBTVj7MNbANZtxTKcmK62zUd84
+MZvgHzusZG3iRyEMUTn6QMKcjSbeN3OzrA2iQrnhIRIPLfQyS/ssjU1d2N0r6U3kF1cfVf7bUm+3
+9J3U6tV+sibG8otx4aTyaq15tLAaSGN+o9q9Tli4jo3GwiIGtEN3AvEi0kjcSaa774KTRCZbrqCS
+OglED3UMO4y9pZ3c5MvVRmN7mRoz0zD28kesB42FXfF72xdcQB/UrRxrNLAnDLPXG1aJjHsdwUTl
+14fGeyrl2QddInv1Qmuiz05GVI4+AJTmUiEz04pvZjaz/qhEiezLuJr58lRchxjZIpsgOYjaqnTk
+KrCpz8IKGgY/dAPxuGsYXy+m/yS1ddahHhLdHUjOiUXvkn5OrH4pPRrAmtEMsOk+J/VsiQUaM6Od
+lCpu0h1B0GAfVfhZzuqv1XLGobPWw6xBnL6YB1cfJq2P5KGxs3Zo3bUDwWPs2h1ad+1AGhj7H4c5
+u5X7boHiOBAWPZwn1g1J4H3GhuSJdUMS2JGx73aSJcYOsge6LYSrHAnyhNU38ciBsFviubVtWAKI
+23PtGFugxTXNbEgf96hVDeSFFHGe07YKt/cRbees9sb5NWmUyP3FjUXiBgR7UdVcGcmMgGRzZUGM
+PQIk7DHM8fGLEA1znEvu1TambNGtvUicS54fbY5HqUjvxcvRUrv60DpDX8oVa9Kv1fF7/4PXyetK
+sB6ZvV0wSOU2o80LVzkvI4O4zemEj/EqjWe0HG9Z3U10S8ISeviNN74JtIHq+hcewA==
+	]]>
+	<![CDATA[
+	/5DRtgqbZOIfcsY1y+IDo7fzwFq3Bbkfhi/zgbc+qHwuaZ6bz5+i4SLMe+7EajzZfS/W/HDu7T5b
+nD/8cvIUkfoMH/e36EZ4Zo1vtqO++eXjdwFLBZf+nNdeb+7LlZSUrNWqxzeSOavAx5RSyhKwRDFy
+8KUxhdpLUtuQBPZxQHy0Kb3SzTfSThaHgf3RdyoM75p2XjSwI+qKWy1u9m3s6JJue6Lt800wS/jY
+ToakEaE18gBL7kbVY5kKWtwZ2BiPrhefge3w5EQvidEAFpYzeZe+/wLcK0UZl97lZ41HbpUz1DP3
+PGh80tOkbYyLMU+0dmxh4GQfo3e3QNIBJboJjexKMs601vgKcKqsxqQIJwIdRnPz7Z4yxB3KL62/
+F/W2yRbGWRmmbvB/tiLrkTjuBL5Uuy3rLmAkHoeSS2U46mMF8aWkvLe7R/Vfihpho/QPA3/wsyBH
+WU6KcqIIP0QsPWpEEoO/3nmGEZLRo24k/pIrqsNKuzls97p19Vd0DYvujo9OcH+R/Jjk4Xo08c9X
+pwuPM/XhUG03RkNlkMR9SoSj1sdqNT/anZaqdGkdLprb7w7Np/gx/NVX6NPEx3DYX8vl+iO1k+2p
+77lWM6d0FETKIMdm2VwymrsEoN13ewt/1TsjvQksH6y1mh5Vu/UvrabWR1o3/Z8Yd1NV6sP2X0qz
+9/XV6w4ICrqDxdCjbk4w6uZ/ZtR///139m+eDJZjYOUA9YYesXddlyGTyv+5MbOyLOcYLsdxGbX1
+lhn86g7r/2QmmXZ4LTwSSOX/DhLa3c9Bs95XKK1Ddwf9elMZ5PTy0EgIeMEFE+Yb/w10DHqtdh/+
+Zge9kdpU3gAjSrarDHOVq4rxMMNkW8NW+PWhvTbBIjHe+JexQphhT82GYwd6t9davSYdVfCAx9/5
+l4fMZAUpy0ZVuZBnQoxZJ+C1vxR1AJ0MM+bxd9KzD4v1HVbwQC5vdl+uPtqDKpX1YcYx9oo+ddf7
+leha1FSBoC4oWcwLKEHwSHsf/kaYaBH+3v0dGUW+4a/+OYpce+tMWuPQtCC9sC++rVMlDSD8gh8H
+8OUnFP0dZZnocfTxmYm2EPpFhFRpRfLRRDJ6d2t0g41W4NFphMnyjCyBdpdlZJZDdQ8bzRYEli3k
+8UshLxSgLMtyoiBH7+oaZI5ChpeznJiXonxBykq8LEW/IrwoZEVokpfkrFiQ2ehRhBdkaEkQogLD
+ZplCnsMyjsmKeVEg9ThoG4pENluQJSkqsIWsDFRKXmWyeVbkogInZtk8S5pjOfgqy+RViRdJa/CG
+KLBRgc9Dj1hSxgrZvMQUSFmByZNXmXxWFPlClJe5LM9xPJRxMkJjsZ6UZTiJlEliFkYuQxmfZdgC
+fRcWEMvk4V02y8t5hMEV+CwrCxLpnigXcGRcHt7l8jAKhC+wBISYhRd46HEhy/KFAqnGZmXoqMDA
+aLRqeYAgiwBBkrJyQSajQJRJMqIY8CmQEi4LI4RahQJgjuO0cXESdBMnguXzBVJWyBZYSSL1BI4l
+KB6bsKPImztBFrRVh0vh8gPW9NWvUMLs32Rwk3C1Zq/bVZogAjLNkfpXfThSQ3F1//f/3+R2/frw
+g2fEvD9P8mBsCaBf8h8yGccX4xErFLJA4DyQPKy8JL4mFRiW4SzdL7Z6DeW08ROQflyHsn+0fjrp
+zwl/qNa7g059qDwlNDBCGoBg+09JS/ukHqhFXza8FI0pxHZtj8wCO/MWhYmYt41Bh5IOIhcEAJim
+YLJpBwyGMH9LHwy+Y3BAk41bmKLB2U2+Y3IslzLLqx+R20g3ch5qcEzg4CZGmBBAulO1GTjLU7QZ
+PLHWNlGusjxIH5RmeaYg4LwZZXkJBKwA08XJKMvgCzwi0heQDNXzZkETBB6LtWWzjMtz8EUsmA2Z
+JTo4eE8vE9g8QokaDaHUBUlkQjMKmhGjS2Ylvdt6O+NjK0f2gIpOwlGREExF2YI42zLkJ1PSJgfA
+TUYOky5jfaaty9ilbLplzM5nyU3A3Jk0X8hj73nh9/B1drIVP9I0bDHP8ryAOrQgSXweiQLEniQL
+wJ2zIsPKeSzJ438F+AKKWp6RxlRtTgStDxRDeJfLk4Uugo7IgkJslOHUgqYr8bCcQC8VQAElZXq9
+PKw1mccyrTFrAaxRGVREfJFlZEsls/U/iuIfRTGMopgP4L2zKIoiKHBg9jFgEOZ5TVEE3sTL81UU
+NTBpBILt/yaOIgZIENnCSqgtT3dm8M9dEaz4n4iZAgPW49//BQ4x+MMh/nCIMBwiQJL+4RA6h8gH
+qoA2HZM4Ab0UEU4SCjyPKAMlW5J0Xx9o2wz6+iRWzEt5oqeIjOyigRBVH3X1vJCVQKnRrA2eF80i
+9NiBJciIwE0ARbIg8JpLjGE42V7mbO6PhvGHf4TkHwFycxb+UQCZxrNg3YHhI1P+USiAeBPmyz80
+MGkEQtr/TfwjwAybTMP4/RzgjwbxhwOE4QCFALn4hwPoHKAQ6AkLo0FYtwxn1SPABOHyZA+OBVbA
+oqlCymRRJjtfUJ6PYkmBIXthQlbmRRFKCmCxSMAuJDabZ4DnlIGFgDHCFixllK1wArYvAc8RoSu4
+1VYoFCTSer4gSpYSmcsKDMcTV6ZWRlyQeeB46MsUBKiObkqeR48pI9KtRKOEOjPlfN5aC3hiHrRD
+syWjxALPLNN7RXyeeUk2e84LEuAF3bLmmHmRB3i8bB0z+vTyHMMSbIkCvgD2GoObuLjlSNx9UMBy
+HFSRGbDkAI9lsuPK5nFHkwdOTPdqwaZjZeDPvCyApUh3PvFVIS/SegzZNbQ0B194GRqBPsh5BkDL
+wP/BTCQl+QLx4cp0ehEkk+VFGfeCmawsinlt45cpCBzZCwXyEbQR8QxXIHvGYoEnO5o4cjRUBYYH
+vIKKjyWAPqyF5qkMkw79Lwi4E8wUcPs1jzAx7kGWsX0J2yI7plAmSoAxgWWyIqeNiaXbrgIjg0AS
+Oa2M44FIBZbNSgJOF44ApZXA8kj11HnNF3DHFzrBAu4QJGAPveAsEgxDISJCcSubhZ7JnKD1ghNY
+rQw34Kn4ZPM89kwG8oN6vCBCvxAXHMyXxCJd6HvbHGCMJ95x3Cpn6VY5TCErE8wCb5EYAesJWUaS
+aPt8lmORqjkkGiqxcWwsFuXRAYlDwkECRQhcIQvMCUDyEjQFXwROplvMAJIXsrDSRFIrD5RGQAJW
+yIsy4JX4Dni+AOSMr/K4McURmuJFeFXAMkQ6LCnyIoejhC8cw2MJPOLz6L0GYgCSQpAASSIzznPG
+iKDXgE+JvCnxHI0IgFUpIhYBkMjwtB7QAUcDAkSeg1HicMnk8shbcNyAE67AUoc54SJlEqqAvlls
+CbpNRoRTw9I9DUkSybgJ1hmBCA0t2oBDJki2PoDFi6j9sNADFnAuIH451H2ARcAa5khJIQ/rrUwC
+HIBcOdItIApCm0B+ArFqeSRcrYwQILQP86f5abBeARYhFokow3DLP09BshjYgRsyMFgJ6ApLyHID
+kLB+GFmkICVgSyRYABeXTEHCv4SgoB5bYLV3cTnQeqggkiKOgRWCS1vQAFBOKkMLUJ2U8BKDnADj
+LjgW+S2SR544kDBQgofRkTJYLHlSlsf9I9oag/OHZcDmWJkgLQ+AOGSrBdznwEXA4GaVjNsXBIcw
+VVgHIGJIikxmElgVKxFpAewxT6cSQDOEN3AohFg67gIwUVKEvB1ZD4+RJrjPJWA0CEUY0CH0QQKB
+jkybbGoxRDxBkYBxH0jkpH/YEnSswFPCF2E1a2UidIB2rECIhysAcCBFStQycEyuAGQuEXEEPI4F
+cuIK0GeQUrR9YHEIEzdBeLIAgTZFKhILAirxPCkThYKgha6QiBmyUAq0GgpkaFfgkMYKCAA6y3OU
+DRBBy+WBukkBLCuxkCcQofcsq7MnLZRFwiAY5AwMDVvh8gW9FoyHIeyJQ/8i6D6UZUkF3GMEBAiI
+MQ7RJGMJOliQfmHt5GWguDJ5DwwMicbYCCyFiAID8QWrgvBGqgrkUTahIC6wJAQGxTzZT8R3gZHA
+VOaBiJDm6LKDAlFGemcJz2d4wgSwKeiOQOQK0DavNcUJREZp40CfKO6gYXdB1kgkhokTJRQPIqkm
+M4JEVBmJgZUiMNAH7AK6k8S8TCUgPimTDTgSooPSE7iHoLUucihaYUFxouaZRe6X54lEJUuelgEp
+yqSeUEDEQgnKCcAGLkAhqqlcAhH0nKgB5ASBBjjB2tMBckhqqDWwIq83blfg/nhu/tht4ew26Td6
+foFRgLDLg07HwkIjdhvwXhAz87XbNDBpBALt87/HbJMCDNwJt4b+mFx/TK4/Jtcfk+uPyfXH5Ppj
+cv0xuf6YXP/rTa4/W2V/TK5QJtdv3Cz/f8vkCgxZDt4pCxXXXZgsNnpEjDx9902WeWSY8AWtadxn
+Y0RZZgpkdnicCgYtmjypA0wcdSAMQia7c+MJfMCHiTQAlRw0QQ539OErsZeMsiNLGag2IEl5rQwM
+kzxhu6C5o96DKgcnkRK5AKrETQTLWJ03MzT1Tysi/I0mw6GOI6IERdMJRDDNfOMwPJpk+clswVJi
+NE+T8mSiWEHHGAmDGI0hQQnU5EgnQPUr8KLZ/fGB30dqfxjqH4YazFBB1/2NiXBokeULoszD1zxh
+qOiBAdNyzplwFA6wVNCc0cXzW1gqKOvTp8hoYYt2z9YY/+KQ9UhkGYNWheyLkUlkplFEORWnuRgE
+kpGkV0F2IHMamwJNXdI4BLqpnE3/YRB/GERIBvEbNS5crzLDopHC8iJlEKAPFJg5RydpcARgECIB
+8JsYxGQ61xQMAv1gcl7TGUBf+jLLUAHhRZEqG5jpgJ5umTES5fQyouDIVOkZa+/P3tcfthCOLbC/
+MWaRFdBjxVG9gadsAcS7NHe2QOGg3sATAL+HLbCTBS062AL7m4wlVjBO7BDFPLWVoIhB3xmWCSJx
+eUMZL6O3kThpMTYa3WNygSclvIjbVej34sgmilbSJG5k6JJgrQXdRJ8gts4UJFuJ5gBsRowy4rQi
+3maisYgiKWGwV1gi4R4fOqfAQCc+dixDTxgp01gelMlMnjq7RHT8khKO09xa6BpjNU8zKZBY4som
+TjuJJWVkcwhLiB+elOB2CJZwZGNKAkwL1OnOU58ieshwWwRRx8qs5iDDvQGzgMX0M4GMVy+T8lmJ
+vgaTVyBnyQBaBfTVgT0pCHjOiV7SpLYuSzYztTJ0cxfIrofeklliwrOUEa8dOtElhgwWPbuSBCUy
+0AwnkrGxdP8LLU5OpMjNiyK1OCUOTVyszWFtvcQ6mWaZNuWkcVFiTbIgB9ZIMm8lHurZFwRrrbzm
+/CVkGCVn0MiyRr64/VGm59IUZAtJo58fsCPiRp+MdjfuC8s4u2yBDJjh8rK1xIImvUzCTSWJIkqQ
+8vQAGq6QFyzTopc0CREQM92sxcp0P8RoySyxkoFRpvWKZ7XUAtpzLh8dW7HlPzr8Hw==
+	]]>
+	<![CDATA[
+	YR1OWP/O025wY0AUZFAjWU4T1oLMc3M/7obAEdMAhLT/m2T17z7uRp7UXUrPOFv9fV5TUIIYEsiA
++2oCiFDMg+KyPM+THX6yG4ob/HRvHUqQn96QcAGy78nhlitKAI7RYimgTgGDAO4jPAd0IuKJKlCL
+o8EguLGMW1B0BxClCoEm03PHWGzzhvSKFVF/wMaAtUfH+4k+DPR+kNASEgDBs5LmNCHb9Cz2VbN0
+UHeQaUQNjW8Bk4djcaMbY2yg1zfEHMKwEyyRyN46FEg4NNK4ALDvXQCizYRKGnaQxjKIGL4iaXjM
+C3h8GpfXtCceLK18gY5VljAFHTeEBTJSlGkSCdHhObLZRl7DMfOIGQz5wEoFEugEEgMEIN1IlXi6
+CQ9lNEJEL8MSJs/QTgkSKhNQwhZkOiOszND38KFIW+dYVIdgcHR3Wq9FlDyMcCB1xDyvKV1E+JIy
+GdUC1C7IpjCojRIqSHhGHW664pYw8UCV6bl1MEQSzlHA8ATisKLBCYCwPE91Q1DHtB1t3EEuU2eY
+IGiBFLJgmR+MI2EwjAua5lH3wU1vsgNNQxPyPM40NC4VMDwKgxB4sq0OeJZR22SAVDjUOHgW9CGe
+BDcxGAdGAlYk7Yw6BpRaQadmokUxuNOJKiwQukTDaBg0KvJkS5rDXVeEBiq0Fo+DUwc1ZJFsD4OG
+JdJ4H3TQkYAcLNNCXIjWJGv1cG8BwYkyqk8wP/+3vatrTRiGor+g/6EvfRmKSdq0DXvahsJA2GDb
+DyhYnCB1tLKPf7977k3jVDaU6ZuPOTaf5t6cJKe3lomswm00xgk31IVIpIDx/E+DGgoQWzRYas49
+Nt5IDOgep5meCOBFHZjr1mOwWbGkgkMbgXgpodBGMqbyNCPa+Qa43M8UOX2AbVkf+VCJ6IQtSTGH
+dHI0gQ4bVTCgHN+/AzBCRiFpw5BjVJztDzecYocFHQD/MUQ0FcIvGiUBETGBZbcBxCrZNeSiDQRW
+4oqd4yxarx+gzVDJkhvai5abZ8TQWGjH6oQCpy8wtCwXRKUIXghj1DiE1V68I0ognWrBbMlSP2y1
+JK1gntC4aFbcsKmQT8lyCFVQCA8JvExmpAhHE58RL4xQEsxC8hUp5jMcMBxIBroPQRkLlKD+23VX
+oJNXv6xhF0Z5YZRbjNKc8VTYIEoo0QRa9LUthFFCU6fUaRmlr8cMqBau4DyU0vzjVPgQSqnNcUEG
+RcDEyltaC9JcQz8dMOiusCeFdpnISsYSYmfxAjzW0ZLFyB7xa+sWBmUmPCCUgyEnQubm0ID2pW+Q
+vg130T423WBYI2gHTYX2pUM3pzVOZ/o2BORHuwI2jUKPAhZ6HUrfH5tNoD73939y0NQOCEd3k7ex
+c1qATjuxzx08jgbvqBk3wqc78NkOaqmKR5O2rl+a2Yqe5xR5n/tmVn9K+om86FefJh+PfDfNelEt
+F1WHbgyi62i3humtfP5j3Mz44x/DYZQkj9W8fm6rxbJuo3lXvddx1TSrNQ3RG/0Sz9u6o7rquHtd
+fQChLP3jSTJ+mETfs7MdKw==
+	]]>
+</i:pgf>
+</svg>

--- a/misc/openbadge_badges/badge-helper.svg
+++ b/misc/openbadge_badges/badge-helper.svg
@@ -1,0 +1,653 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1"
+	 id="svg3004" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi:docname="creator.svg" inkscape:version="0.48.1 r9760"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="108px" height="108px"
+	 viewBox="0 0 108 108" enable-background="new 0 0 108 108" xml:space="preserve">
+<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:pgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:pgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g id="g3014_1_" transform="translate(0,376.07634)">
+			<g id="g3016_1_">
+				<defs>
+					<rect id="SVGID_1_" x="8.996" y="12.472" width="94.089" height="88.952"/>
+				</defs>
+				<clipPath id="SVGID_2_">
+					<use xlink:href="#SVGID_1_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3022_1_" clip-path="url(#SVGID_2_)">
+					<g id="g3038_1_">
+						<g id="g3040_1_" opacity="0.75">
+							<defs>
+								<path id="SVGID_3_" opacity="0.75" d="M97.635,57.893c0,24.043-19.487,43.531-43.529,43.531
+									c-24.041,0-43.53-19.488-43.53-43.531c0-24.04,19.489-43.529,43.53-43.529C78.147,14.364,97.635,33.853,97.635,57.893"/>
+							</defs>
+							<clipPath id="SVGID_4_">
+								<use xlink:href="#SVGID_3_"  overflow="visible"/>
+							</clipPath>
+							<g id="g3042_1_" clip-path="url(#SVGID_4_)">
+								<g id="g3044_1_">
+									<g id="g3048_1_">
+									</g>
+									<g id="g3046_1_">
+										<g id="g3050_1_">
+											<defs>
+												<rect id="SVGID_5_" x="8.996" y="12.472" width="94.089" height="60.786"/>
+											</defs>
+											<clipPath id="SVGID_6_">
+												<use xlink:href="#SVGID_5_"  overflow="visible"/>
+											</clipPath>
+											<g id="g3052_1_" opacity="0.64" clip-path="url(#SVGID_6_)">
+												<g id="g3054_1_" transform="translate(147.3794,85.8701)">
+													<path id="path3056_1_" inkscape:connector-curvature="0" fill="#B33333" d="M-89.623-14.21l45.328-10.739
+														l-4.811-11.497l-29.209,11.827l31.233-28.749l-11.184-7.164l-28.445,35.326l15.784-46.417l-13.273-0.455l-8.127,44.384
+														l-8.562-45.706l-12.344,5.011l14.763,41.621l-27.216-34.201l-7.569,10.913l30.339,27.546l-34.05-15.046l-1.419,13.205
+														l40.594,9.439l1.426,2.298l3.771-0.895l1.432,0.715L-89.623-14.21z"/>
+												</g>
+											</g>
+										</g>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="g3058_1_" transform="translate(57.3389,463.82834)">
+			<path id="path3060_1_" inkscape:connector-curvature="0" fill="#862626" d="M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248
+				H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3062_1_" transform="translate(57.3389,463.82834)">
+			
+				<path id="path3064_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3066_1_" transform="translate(72.5313,439.77264)">
+			<path id="path3068_1_" inkscape:connector-curvature="0" fill="#B33333" d="M-61.955-354.134h87.259l-2.13,6.917h-82.202
+				L-61.955-354.134z"/>
+		</g>
+		<g id="g3070_1_" transform="translate(72.5313,439.77264)">
+			
+				<path id="path3072_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-61.955-354.134h87.259l-2.13,6.917h-82.202L-61.955-354.134z"/>
+		</g>
+		<g id="g3076_1_">
+			<g id="g3082_1_" transform="translate(63.3096,106.6533)">
+				<path id="path3084_1_" inkscape:connector-curvature="0" fill="#B33333" d="M-58.546-48.095
+					c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799c0-24.262,19.668-43.928,43.928-43.928
+					c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669c0.656-2.941,1.054-5.981,1.158-9.095
+					l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66l0.715-1.86l3.229,1.242
+					c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665c-0.748-1.979-1.618-3.899-2.604-5.749
+					l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209l-4.565,0.718l-0.311-1.969l3.411-0.534
+					c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119c-1.622-1.334-3.334-2.561-5.12-3.682
+					l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908l-1.251-1.55l2.694-2.175
+					c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952
+					l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314l-1.859-0.719l1.248-3.227
+					c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626
+					l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566l-1.969,0.306l-0.529-3.41
+					c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053
+					l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609l-1.553,1.247l-2.17-2.699
+					c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394
+					l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+			<g id="g3086_1_" transform="translate(63.3096,106.6533)">
+				
+					<path id="path3088_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-58.546-48.095c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799
+					c0-24.262,19.668-43.928,43.928-43.928c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669
+					c0.656-2.941,1.054-5.981,1.158-9.095l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66
+					l0.715-1.86l3.229,1.242c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665
+					c-0.748-1.979-1.618-3.899-2.604-5.749l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209
+					l-4.565,0.718l-0.311-1.969l3.411-0.534c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119
+					c-1.622-1.334-3.334-2.561-5.12-3.682l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908
+					l-1.251-1.55l2.694-2.175c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604
+					c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314
+					l-1.859-0.719l1.248-3.227c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398
+					c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566
+					l-1.969,0.306l-0.529-3.41c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27
+					c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609
+					l-1.553,1.247l-2.17-2.699c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277
+					c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+		</g>
+		<g id="g3096_1_">
+			<g id="g3102_1_" transform="translate(133.7676,136.4482)">
+				<path id="path3104_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-84.59-96.67h9.725v0.986
+					c0,0-0.304,1.084-1.52,0.761l-0.76,0.169v18.668l-2.584,2.41l-3.038-2.189v-19.059c0,0-1.519-0.105-1.824-0.433
+					C-84.894-95.685-84.59-96.67-84.59-96.67"/>
+			</g>
+			<g id="g3106_1_" transform="translate(136.9014,135.9277)">
+				<path id="path3108_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-85.749-95.822h6.686c0,0,0.911,0.548,0,0.602
+					C-79.975-95.165-85.749-95.822-85.749-95.822"/>
+			</g>
+			<g id="g3110_1_" transform="translate(143.8926,133.6768)">
+				<path id="path3112_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-88.333-92.151v18.619l-0.861,0.327v-18.668
+					L-88.333-92.151z"/>
+			</g>
+			<g id="g3114_1_" transform="translate(156.355,123.4932)">
+				<path id="path3116_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-92.94-75.549l-0.01,0.01
+					c-0.512-0.498-1.208-0.805-1.977-0.805c-1.568,0-2.841,1.272-2.841,2.839c0,0.771,0.308,1.466,0.804,1.979l-0.004,0.004
+					c0.019,0.016,0.035,0.03,0.055,0.047c0.096,0.093,0.198,0.177,0.306,0.257c1.804,1.601,2.943,3.932,2.943,6.533
+					c0,4.829-3.916,8.744-8.745,8.744s-8.744-3.915-8.744-8.744c0-2.559,1.105-4.857,2.859-6.455
+					c0.763-0.509,1.267-1.376,1.267-2.366c0-1.567-1.271-2.839-2.84-2.839c-0.775,0-1.478,0.311-1.99,0.815l-0.02-0.021
+					c-3.029,2.645-4.948,6.529-4.948,10.865c0,7.963,6.455,14.415,14.415,14.415c7.961,0,14.417-6.452,14.417-14.415
+					C-87.992-69.02-89.911-72.906-92.94-75.549"/>
+			</g>
+		</g>
+		<g id="g3118_1_" transform="translate(0,376.07634)">
+			<g>
+				<defs>
+					<path id="SVGID_7_" d="M10.102-318.612c0,24.345,19.736,44.081,44.082,44.081l0,0c24.346,0,44.083-19.736,44.083-44.081l0,0
+						c0-24.347-19.736-44.083-44.083-44.083l0,0C29.838-362.695,10.102-342.96,10.102-318.612"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3120_1_" clip-path="url(#SVGID_8_)">
+					<g id="g3126_1_" transform="translate(201.0342,157.2715)">
+						<path id="path3128_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-109.454-506.695c0,0-0.747-0.257-1.357-0.654
+							c-1.307-0.851-21.334-0.217-21.334-0.217l0.667-0.552c0,0,20.472-0.285,21.284,0.129
+							C-109.384-507.577-109.454-506.695-109.454-506.695 M-143.388-500.48l-0.02,3.125c0,0-0.077-2.039-0.916-2.181
+							c-0.838-0.139-0.358-0.953-0.358-0.953L-143.388-500.48z M-109.159-508.086c-0.732-0.806-4.407-0.744-5.435-0.761
+							c-5.566-0.082-12.748,0.203-17.945,0.163c-0.21,0-0.935,0.348-0.815,0.645c-3.694-0.022-1.77,0-6.23-0.066
+							c-2.414-0.037-6.245,0.872-6.355-3.396c-0.061-2.127,1.896-4.011,4.221-6.279c-1.47-0.462-2.962,0.525-4.452,1.344
+							c-0.731,0.709-1.227,1.19-1.838,1.785c-2.278,3.288-3.179,6.6-2.667,9.929c2.038-0.378,3.535,2.415,2.094,3.72l-1.271,0.012
+							c-0.602,0.004-1.083,0.619-1.076,1.366l0.022,2.96c0.006,0.748,0.5,1.253,1.102,1.25l6.417,0.038
+							c0.603-0.003,1.083-0.618,1.074-1.369l-0.021-2.955c-0.005-0.751-0.502-1.356-1.099-1.352l-0.802,0.007
+							c-1.395-3.988,1.211-2.796,3.79-2.755c4.848,0.074,2.567,0.045,6.838,0.074c0.243,0.297,0.121,0.839,0.791,1.124
+							c0.415,0.172,22.823,0.246,23.283,0.14c0.462-0.108,0.343-0.331,0.512-0.497C-108.8-503.849-108.279-507.122-109.159-508.086"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		
+			<text transform="matrix(1 0 0 1 17.7725 81.4541)" fill="#FFFFFF" font-family="'Arial-BoldMT'" font-size="11.7746" letter-spacing="4">HELPER</text>
+	</g>
+</switch>
+<i:pgf  id="adobe_illustrator_pgf">
+	<![CDATA[
+	eJzsved6IrvSKPzdAPcAtrHBpM7QzkTnnPMQ2jZjDLiBWWveH+faT5XUmU6E+fZ+zzN77cGgVquk
+UqmSqqR47OwyU2z1GkqGzzLRSDxeVpX6sKeuRUlpdL/TGQ2GKhYlLpJRVswyUKm4X3jVKt4o6qDd
+666RR1kOHtbw7cSZqgyGvW50r9f5UgbJaCIJj67aw44CDxv11ruS+VA6fUXNDn69J3XA0FKlPoQq
+hRwL/+ej0hrLRs+O8Xm9+6s+GLT/B56yEl/goazUG3Vb7e57qffvWpQT2SgvFKK8xEQFAR/vtS+U
+gbNOVpawklDIyiK+IcpZQZB4eIXL8vmCDO9Ves3Rl9Idnqm9pjIYlHudnjpYi5Z/17vR4/o7PKlH
+75VOp/dPtNSpNz8tr9R63SFULarteidT6nVax1eWpyeK0lJarnWK++Jrrd1RAHtf9WGUZRHRxX2W
+ey2N2p3WyeiroQBeeVnGYv6VdOp6AL2BjuF3LM6/7n9ByaUyHMKIAQZO1sVuyToQKCT/JR4vlPc2
+mVvA+nNSa1bt9b/q6ueA4koERHH4CVgSo4LIZEVa70r56ndgpghWeUbEOrKEn+Z3rSYMitRi89gE
+tBAVZR4+83lBr2MiXPnVVv5Zi570ugrFSVEdXtI5FwSGoZ/0ycWoo6jX3faQjrO4L1OkHPdaSgfq
+G+/XOnWCC/Ifa37SCld19V0ZAqH0OqMhoeSCDgGQflT/reDcsxTAaV/pXvVuSB/ZPJfNw4gkOcvB
+H5iyPBeVeC7KSQSGJMGaEAywrPlJW8e2sCUdRB7m6gxm71Rtv7e7a1oH86+7artlzijAKNAPMoZs
+wfJP1v/RzsK4h0Olq3UeKKl8bKEMJnt8CRCr3Va594XIH+CCApLoArV0eu/0mfGdPIHXR/3IY4SX
+c9+j3lAZQFsdJSpLuXe1/kuJslwhV2y1FVj77UEOCLz7nis3lVa706nnqvXmaKjkToZAzkruVK8W
+yV0bb9RplTppLVdvtlWgi7eO8m+ubtah79dJ4029cYW8Gckp9FXF8qpivNqmzbdpnbalTtuo0yXN
+R3I9WrdH6/YsdXtG3R7tyohWHdGqI7NqJDcy6rbq7++KmmtBBxUl1wR85wZDRe3gKAZKEykv1xh1
+Osow16+riIH+Rw7e+Kp3W40OYEklqxVaa+Wavf5vIJKPYQ5Wb0vB9ZqjfTDAZbu9YUt5yxWrudNB
+pz74iBhFfeDoX+3uyKyk//2tdHNfI2dxZKye/rentt4UaKrdVfD7V33QHHXwh16hDuUa9O8RyAMY
+ZKv3Tzen/Nvs1L/IV6CudrPegReMt95gEbe74914B0bYUb56IEPehuYviglgx+0+jnzQrzeVXJFO
+RlEjNu1PNddDGum2oEs55Yv8IYQMKCaN6j9om+SXWU4LW+1fbSQQA2kGzu+Nb29qnc5odaT2SE/J
+SjH6TX6R5iK5tzYMWCMPgJwDkdjutZBAyFyb66xRHyhGB8kPqDr86I0GQCKRXNFColXL9yKljKrR
+uSpFzT4t37eS675RaZ9WOqWVTi3t6eM+pTWuaY1razPX9FELZwokds7yNp2Ir3pTRXoHdk+q1Ztk
+QdAlTVd0JPcx6r7X1dFXpz4awjoEifCZa9bhvchVlXBQ8eD1agBywxQX/CthU9Vus4cify36ahWy
+don7mLM9zNlqUqZ99UAbBT6oNxm9UkfK1e++EnlkJVZbziAK+BygRfke1TvwQ8q1u2+wLIa/LYsN
+UUEqAK8ETQfwjD8ibIHFNQdrfgjwW+23txyM6YsI5Vxf7bVGTeAIbWhxiLwNmi/IudMv5b0ejbCy
+mAMGgOsnysr5XL0PL/yr9UIu5CpKBzQVjhU0ooXF9j9K912JcgKDlTtAxq+Xv78avc5rjv61jVyk
+6HwF9J7B3KDkiJz0I0T9O+uM4NGu2hv197tvvUiC6otXQPmIptPGT2BqoPZpBea3y1F7qGTr7X7S
+tyEQXqoSpQ/hZfJT/xv8dkV5Az3KfJ2WVru/lE6vb2nWKIElFL2tq/3gps869W5djZJyo+WjNki/
+szrgyGzbLAvRKGgAfZQCv/TOOQD4VLA8CgGoPvwApRVY4MBom/60d5yWBbd32UQdQ42W1NHgI3rV
+63WMZu2PjNa1YlKK9f87YJyRF7qnXYqgcUhaBSckUC//66BAbW8I8PC/ufVyHeQ4UX7aTTcALs8N
+SPTZJIRFWF578GXSk6XkDFlys6Nc/ga168uvNcQG8PsWECLhbmZve199ND+jlx/1vkLaHH7USM1L
+o0ER5YuVx2Yy/sx34hdk+gRNqeFvkEOR3GEXdC/yI7oG2Oj2AH+5k/qXEk1HcpdtsO0U/SkTPY0w
+FiuGjd7VI7odxUTvfsOPA/jyE4r+ibJM9Dj6+MxEW1B8d0Eq3oF2QnnjeiQKQukN/jp68Ail9VFn
++DxpNwACGGEMB93JSnlZKvDkC8NxHBpCDCvpFthdMXyvWY9eE1wC8k1MBk7HWR1UerBMEOpZI3Rv
+ndY5GfXd/0TGrPazZuSsZHRDhzYJORxBc9YZGBslqTAN3bEMfURXFTbz/2nF0JCj0KNxra+6g6BS
+H9Yj8dec/hsIA3+1ibZdV3+T3yIncIVobh8eJ6CFKKzjRq+utqJNdA9EuWijM4LFmA5TFVTwkDVR
+EezSukw0VwIGRCv2YeWr0UH7a9Qhc0arcJamYDK7YLWoSrf5G5ppt6Lo5aL1WE+Q9Lkkirzo3S3W
+2i2k6tyFUu+c9QDFUGDTHdDN8AqCs6OMDYJloy0d4e1BD/0+gEOFuNVCdsNEeWBVA+WsyND+0orH
+CjD7izrawO3/IaiMml4b+oaTEowxgGn6Savwkt5mv97SAAlad6AHGlrz+vy0+u2sAx91kA/G5NCi
+Qb83pEXr2NdocTTsGV3Vxp27Oz466bUUV5KF1/79AiO4pWRAA1DbDbCpNCBgmKh1WutPNzGH9i21
+mh9g66mKg+D1p/gx/N3XkJNY7g5ef9XVwToIgMshGoL2qr/qBgGR8oFHvS4ID2MmtIrp//XYAfms
+hEBMp9f8xMUTjBm95pwIc9pxNdqEh7AhxgbEcakMT8gggsdnrT2n6Z8RE6wvJkKNv10HphuG8ANn
+9X/TQl/7FXqpY9X/MEXj8JqjwbD39Z/lZH+ODtcGddTLURODJRaWHP/4uoC+/Bd15f+FVTp4++e/
+WBr/h5fBoNNu/m/nxbwoZTmeF3SF2Gusv8PM7u//NOvlRCEry4WgwfwbilT/04NhGSYrsCwbNJp/
+2q3hR5gRaRX/s6Mq5LNcvsAHDepDwZ2xMKPSa/6HJ0s3A70G1OgNQSE4Ut6GdG8/zNDG3/kvEP6E
+6132RmpTIWE1/3HpDzLqP92FL2VYb4EyNGs/5Bn7sai7aMJQl6UyeZnE+jD4PxrkQ75aGrq82SWh
+QaXev3f3hj+E9BeLi6pSLxIvkrbQWRljh/KygH8CfE5I47ipplz1+qSWvX3P6jftQbvR7rSHvy+H
+9aHptaLMxflardPrqadvbwNFa1/0rEoWXb/ehJa1qgXPuhfIgKr/DpWgbmOgkiZ2GZtb63Q07I+G
+AY4tD2fcZxfs+B68/U73ArFqPs8i0rUpCIH7m3q3PfiAabYgX3u7IEw0gSXCsyzN8FxeynsghGBu
+1/ROJlimkGV8CG/PwuwZw4EI6DCcwSQ8KXpU776P6u9K9KzX15FCAgaNd/QXaEjhpemis+ieDgGC
+21jUTYnOCpjMJiwpvZOmn8EQBfsD/QXNr27W0fteaQ/6nfrv47r6qSOdz5OZI38cSCfRblZRQMPz
+yGq11L1QOle9C1qPTlZv0MaBkKesrvjJRmRf2Fc5Y4DaQiheONiaPmCCxJBzemuqJV4Lhyxc3wXv
+Tl4mvva7LeXfWlsdBCxR5yuXSrPX1V3EYiEv+PXQQsk+7AKXipVb8J41y0qnY1ImK/rVK4MsHupU
+4dniXg/YS69rXUacx4iuTEvw8VhptUdfFo70PL4A3JahFn2oqFEMBVaGUXMFWLcAXNnChe6b9Jwq
+rFUyhB9rY48EnvpLiV4p/w6j1VZ7WKdkM85Lmeib0U3goxi8Fh3CW+PNWmv2dQC9X4rax/0q54aA
+44Vmp92PNnvoN/k3ioF8Pd0SDurMYKj2PnUVL8FoiynKuK8qDCe1iOgEjcm2VPos7tdGnY4+VVrw
+Njw1zA6TsVq7oxLplPkFU9BTo406LMemzjSd9qxND71UOnv1IcDbx3i2/crAwh08ah71mvUOEou1
+rrXCFTpZEGqwkCFL06CmwJomReVlwl4LPCtNIABxMVqXd0HKh5fFhKZnFsbIGnWerbEub3aE9AKw
+QBINzQmdCBzptLvwn0gJNNuxa4HIKnwUQWNqxYJcYH0qmjMreLJSrFerN5UiBjUHVSYddtT25Vbe
+Iqwg8OFpzWzLSWxMNCPqqqXP+wpuQ/9SCL27UZu3ACGgbYoxJ3Gsl1REbFqFYoBmbm12Has2e2pL
+aY2zmGjupDe0PfaQURbhxEWL+34CyaaSgwSpnl1Gj5D9YjwThgYSSeKnlBMIpxrTvnKVILTZMoqC
+siYKLqyigLXqtFj11CldrPvhFOIuhn+izMVO0g1yRyeDkUOB+WDHDpdWDwacNzf5aV+phZO7oTKk
+ZJUhrKPq2MjH0Kij+tIqHwPoRIeSM10nuZ+9Rnbw2e43oDefTlPbWbEPVoUK1oWuG40rQs439OAG
+y1tevSDjrXc6+isDO09xVsfQaXWg4OhU/5rNXqdj8Jog6Ia01TQpjH866DUwzi1qilzGcz7cSZ9M
+qi/luy8k2+yy1qiabs9UvqLtLlGu0FxxU0rGKcENVc2OCqjqQqNDDOcYhJ5j07HCmmzE1rLayg4w
+sCb7y3sSml/ZLwCiQb3OXmajt0oD8AVT14o+JS5vT8+ektFfnH+HoJm+2ntrO0XSWB2qwfaGHzr5
+BIy0//71maU7m2brbgP5t59FddcbPGlpgIFlAXWULip6rZC4/fBpbZDtKu910z/FuWMFY+xN34V7
+Qx1Yd9oqyXOu2IUegaWFSYI2UeFKcAYNNzCP0KcuGWa/0/wdgDNkUW1YrP5NvcEEffTU/wlorAlG
+ekAVmCBjhlzqvHWH2VbHQtghiAzW1BDzRP0xZ7YpudEFaYkkMvbe3rJDyzhcaKjfV7MfLt6lsQZV
+S+ylT4MmZhC4amvYnYSRDjr1vh8RU1T21beeIRa9OD5l5oNGe/hV95lAo6qdXwSNB7OYgggHQ/ka
+dXUQNGz1XeeJvnX813ajjXzenyNpjJ3Ik9BkEzRzdrzQHRtfDq+z3ebXb7/FjvRIgkIDibZncWjz
+7hwSEDT4qLcwryvUGgRlZZCtd7t6RGMIPFlHzjNuQ4IpUNVx9dmVwbIoy+v6zkQo/5MDVHfM1+qo
+0Ou3RqFHZ6P3ICIY+nFMArnZ00dmiXn3k+igvtH80HEXsnOelSG6bLrKYOBNhoNhJw==
+	]]>
+	<![CDATA[
+	26KQ+/2WT3tAX1TehyIbbJZWN1p1g46tatCDiPsfK3EzmGPthX1oENVFyx63m4A32F1D27r0mSaN
+X1hcgaJHzXcnWYseMrevedP9+XFLGbTfuxYBI4FG7DZuRJA5XrbgVamNBwJYaDgve7YXJAJRAg1G
+jUHwzIXvWIBktojGX37WGWFaVmr1XH4D/yUEEz8kwba+db6QkQ98J5P0yKbBJmC9A5W2oo3f0YoK
+uqgaoAwBkkxOlnejKxiRzRfrRVVUE3BSquv6tHGz0UCp9Jol/BlOeCAXgPWPylnH7HuYl3BhKmrX
+upPmy7pofX81d9juGBkKrhKZaNXN7sA0WV3l5xhTHa9Fplv3lw98mAutOOo29Wn1XI50gVhlqygL
+/pUtCovdhC/qtS1GvM4jL292q18NpUX9M+MGvmju7Jy1/1U6Z4r6pjSHdrRCI3isySWwB3rEhMNm
+H3NTd3XN1Oonor4EH0eR3VFHfAWh/HR6HytXFUfHoBCzNQ6B9hxDhyd3eietuNIywcfbOXt/GwOI
+SDF303jzwZmqNNuDcV8iPMJB0BRLt2f03BX6RDDbI5laV9aYJGsXcE/FxXE5NisfvX/22i1lHC7J
+ZySbMni8whiRXNZ/KcewLNv9jlK0O7ACnbeWI4ai81WJkETOKrXXK7Xe7/uZqXrFCp5R0dU2UDpt
+3doO4F/621pm3u+TsIxPf5GGgJR73ZZFQ5ju3f0WrNP2WzukV8feCu7RkVOP0B6ceBQW5FnevfoA
+kyeKufzDDyWqce+oxiQG0X8+lG50UP+Frda71uOmotiJaH2AxVpydKVmhL5ko9cD0iR82hv73RtF
+YYl0o71uVEGkQMsImjb3Xm930V9oAZSOAjDj1S7Iuuiwh000lWibOBfr0U79N4bZ4JkJbbqSooNR
+8wO7t9+tEJ3NbIZC6wKTAvkZ7b2Z4NuD6Kj7iZmv2dA4bartvr/M1itrE7ffbcLYHCTs957H5Id9
+nRy6VCYK8yRQL4fAsIFN+NZk6bio1Vxsqr1GfUjPS/Jd9YHb+mFfsm2/u6pg4TfKQ4D1jhOw7MHY
+3w+VF+mBJoJdbePnypKE6utPCB2zNrnp7ugS7kuSvagTX61Qf8vYNLI4jD0rU0UFReMF9t63dYGs
+RE0PDu4HqQZaienhcUOipe6Vrw1kq3oR4JGyVS5ZVMfg2keGiejqEzGwTIzymtr7Ajn/T0/9tEKZ
+7E1j3JO9Nm1HL/ytW5PbEMsCw/JMdcrL/aC/dKW2v/CN2wAT2gAC2vq+r5ter0m4a6kewPBYTf/A
+PoSoqXfXx01kwqfGLiDRrnO6VT7udXvND0C5UjZt5MO2HkTn7hscf7kCApJmmTl5iuDqhrG2YL5L
+jkIsNnq/QvAON9hmvzlR8nl3V63/xkMOL8eS9r1qW5BzPqqbkWkc5yFhjDe9RxfUQ9cJcfdquQN0
+TkXQICdHJCH18JjU9A53VAbCccWH/wSQ93zoyxeZjpcnwabjVbO7vmIdZPOt0sAIrxDzhdoHWJVX
+H6OvRrfe7gzs9qoXYwDRaY2sDKPEWRTvKtXOy/U+jc9sK/6si6iNoPYTDn1l8e2sgyVbqVFdoWzY
+hvqzMZPTPMfFfqwIdpUeN4IWuP4sQoZgLUEztnhZ3t8viBUFdRlsNbUl/sintm8aOSaXOk6ntj+G
+PH7jhI3zNd54cG58Iw/W+e2rYanyJu9+7i1ebNYrb8z9lvGUS21eSB+xlf71aizN1YqReCx9fKvE
+EkuPCfh2txtL8rtfWf5IjqW2dmPLwoBfOieQhe3TH1vM3o+DbexXIbUlrS5WFLU0qqaOj24rh/ux
+S/1p5TObG4h78o+r3c3qbUm5iMR3coP3jbXns2O58lDZ/ljfZgvZUvJr+bL8vN+pVB9/pOrsajHf
+FWPl5LkGdNJRwVhW+lffsfTHz71YqpmFob22HnGYl7HE3iCNP++1oW3241MOLRIng1sfvd8IlUUl
+vV9Vn9RCcU/qXcKobgqVxdaoWtlePRTXHw6POxvx3HcZhrbWswytnFm9EAbckeQ1iRzMPg4Je7s0
+XulooKrrgyv16SG9z+SEy4R1GK9KeVCoDW+4l97nMtNaZglST008qc/MYANaLoyQxsgkc4Njfd4K
+u0Lhe/0n/NztwNv3FTvQJ/X5+OncHehu/kVc23/JOoBqY1Fflk6OCFg3oFL7cDfuDnQjllAHbFx1
+B3rGPgkL3NpqJO421sFK+jjjAVT8SNRX7qvuQIX7O6bGrB47gAIUAnah1pKW8hfJEzegTO3qtuIB
+VFqMn10Wi15AfzC7iw/XAMVtrAu7mZ2V/Ub2znVWn37WJQ3o2cqKA738+rDTIkCBFhtVAhShaLN6
+rz5zBycINDk+q9lHYfO4nAKgQm+MlF42ap5Axc7pwjASd4A1gNbVl+X4jQfQWlPqrki8K9BB8Zl3
+ACVQKNg9ofd433MHurGQGKzkl1U3oOroBxtPJrYfn92AMjW5CrPvMVZpcenyRl13ByrcPzO1570L
+15Eu1Abr8c/czaUJNBK3gN1Nj048ga4o7zunHiON5dRB/2wJga6Oofe8ButlO78TOwaw+b5zrEf5
+0r0G9D6TcACVLo8+byjQ6tNnzTbShx3m6LEqmkBhLJax7n0P8p+L55Ir0ONVte0JdOfztVz0APqY
+BEq+XFMGrmNdOMw8HbaU9NAV6OXr9ron0JOnvYOSCRRozAa2zNys3BXcgR4tji7fG62CK9CbI7bn
+CTQSv97N7Xa8xnrI3PT5HQ+g28mbl9sfRVegt9uNVRMozIsd7OtrcXjrAfRJYJ5Pr5LuQE9O33/e
+VTZW3YDCvDwPs+eeY/06Sy3feQGtMa/n3xvuQE93kupjcVAmQCNx51irPzOSB9DCXuz2hDmiQOsL
+w137otlWR7ePAgJNOYBG4oPC6eJ68mX09QpgN1Un0B+rF0sa0E951SFplpnjE5EA5Va2Ent2oFl1
+8H6wiEAzSGNOBnGUjT0tSjUAujMYY4VPPZkC3U5U0w70xoq10xUK9Hm4dmACjcQBwcnr1Pre5gGC
+zY2zwms2kz9a/glAayMnULW9ndSArp1n7SPduy7FlzcI0Eic374+OrKNdfFxIDYezxAoM8aVTuTl
+hbvh+T4A5ca4s1psdK9TcX7D8VSTyKpaKqzcXx89Hbi+ParHNpj9p9TQ4+nKFlsfnC26PYUZqIE2
+HouXlir4fJwa9xpdKV9bYvGpk2zg6UdfF2VuT7tq/vR5TyRPXWZ/bzgssFsPefe395djO6e31XOP
+p8P1w/2DxYHjqaHDHDLPR6mUOHJ/+1B6PdnZGq14PD18O1vL32RcnxZOHtiIIUu59DinYpaMucyM
+P5WWr+uP1S2PpxuJm/LG7Q556oKxo9Lq7ZLaLnm8vZd+LUtXT+5Pj4u1n5tJPul4amDs5OLj5+C1
+mnJ/++Tu5xc/yHEeT7++e5lPpeD+9P75LBKXLuoZj7efVx8N6h5/+vp9o/NDl6f1O25zIZ2veWFM
+uTupDRdOFfe335jnj5Wf+wuuT+O3562bROxk2x1jqrr5es7vnCcS+Dw7tqY3udL+6XnpC5+OMSG1
++Po1iD2vVFyfjn6sgRRbjW/Efng830yu7tyu1s2nW/3kRp98Q47WJ0xqS95b+km4F5h4Z2XDNDMN
+73NT7tts6NXDdTaWrlzcxtI3L5doXF7FEo/JEX47AxPzsxzLHL6CLnT3maevbW32PqE3lzsEngk5
+d1zorqA2vnk3IuYOMNe3DQPoYq692UiChrdQBXMnZ+eb6gK3snmW0YydpZ5VBG8t8sj+D76osdNY
+uvi0yn0CVgMqJJ+8gS7UXjKeQJlaSTp1ACXaOAELinGXX3/1AHr/4gN0NyZ6A93dVe8tcp+3jbWw
+t/gtjZ50oLsdK9CN2LMVqHC5ZEXv+c6FBWhreRn0MRNsar1zfeIBVPxAauu7AxXu772BLtTeGduq
+RLBWBIPt4AEUrEmwHRpeQOsOoJG4DcHMmidQopF4AkV95NoLvWliJXmOdX/ZMatsGnQNAp580ybi
+ZNTyrxeJazVPF5UwLS6cbsZC1FNHr59xk1tolGzzEFmXLrydTqRKvcEJpX74Vkb9b58gRsesseJ3
+Ty8Ax8dp7WOboe4bbfY1D5GQvrCup7NlYI8rj2WtD/WLEnEnbfUTrSsnYwLwpdyHUonjx6IBQLfF
+NAD6WoT+PFbY1dLPGlbiaROms2lrqxq3fABnLBtKvsNHd47d/CZViB9GG7DZZeZAjMfJBxKDzdDQ
+Bn5qjKCS2mrwexYEWvC+e30GP5fjRL6MVoM7NdCruHcp115cS5MPik+7z9OwXinSj0bBSCcfF1ab
+3GV82+zhkTk+HMv4CLWP+l3FnEG3+eO3b66Og+YvfdyLxLUREovI4fqk41tf9UdWiPkDSqYzuHvZ
+nQxZ3sSwe+Mkdt1D4kvubshi3la+7/wpy6QrQsnelNVj60sreyEw7493wsfWczNjXkdWY+CGdzov
+gchysJ77dNfJeqpP5b4VgDF6bD4Sn2A2Xqps9XmwazTBuyNw93BZU8pcV2X16XTo2R/SEeTtafx4
+tDpdx3BXRQv60LYqrYzbdVUmPYfGL60fHoUYWiTuGJxtaE+LvkMjiF6ma8irI4xSf73WfLDj4sgc
+VXKZjMqd2O/TfbuYcB1QxHW2bAOqZG10bixDG50zyll22a6rW6aJQHn6nh0xb2uJBy8pDTq/QTam
+nE75NFbOPno25tmUIZEd667B9Zzrrr5wFGLMrqvOqvNDf+o1o5LHXKarafqhzRXrti13jlJ6wZxO
+G405JhQ/NC5InNgutFFfOGY9aSP30Uttki5F4raerX179Iz75koP8oH7INOlhIsWlrJjzDEln4W+
+Y0rg7WvVV8YFsB6LFNtFxNQ8BJO7zuhBi61dO1flLNbrpPP7WRiF1Z4M7cJtz5giqxHzRxaOL+ff
+JZz9T3nBs1NmfzxVOluXPha9ZeWOuWqDhceuQ6UbUyxeRyu+Or9tBoNUuvDzp0ZMYTV7Y7AA6lW3
+piLxyRsLsjvGmzK4pUtjdpqfDWNBet0Ejdk57YwYs3O0iTGmebY0QuNKd/cZu+G6h0ulGlY7NnXj
+SHyst8OtAM5hUWjdV8H7nmMaXPiYqWC76wp7Tkt8hlX5vsc9j0qHExjKQs99Jofb8Uh8ZuyEMPsi
+gdjZPfsK60bwGMvWAPVkD7YQfprGTTxHRyJhuhLEBQI74qJbToUTz2VvzIvDNmzwSVcRVbp7FSaz
+DOmWpqFb9m0BTmtki/zCGlCUqAwnA2B3alh0mH00cXcnYB8eCwTMMKeEt1p8ITpl7dIEDMAadTO+
+5H7uz4cBIIdJVJdnQbplfNtr58du4wN9bEKkV4ZBmoKDZkGTj4wH0SHVPg8+2DmNb2v3vq/rluF8
+nV42+c995o1duPckhkh8ImT5L3E3ZJFW7LtvGrLEGZBlX+CbQ7LAbbJymz0YhbC6gw==
+	]]>
+	<![CDATA[
+	vUsHjgXu6SHx8yWAnrzk3xuH/m7EKI4TGr+0ho6CIKM4hEv2ADFm1+CnGlrCf2iREA6OgzGxPKl7
+g6z9rwNGGXzezjigg5Gnjy5i5Xi+fh9+Sf4WQlCgG1os8gUR86pO4gPx8tcAbuz+Gi9KtrACm6fB
+rkpjaDJjV6UPnaq04SEJUqbH5mDtfHEi3Fk02FNrf7z3pNw1YQ/c9Q+JGKSy0s+5GawJw9DmsF4O
+nTJwYjpHjK2dx+ziL7Q32kLn29dx3nNAkbg/pdto597bx+7PAEwa6x865d0UDADQ4uYsJJHDXqLO
+Q5dF7OQnkkNoieva7LioSyZS9vgNGNXdpdu68191Xl4FYMJT7k9YRqXUXzOOXdEgeecp7bCxXLj1
+EuxvxcaY2XlyGTC6M5rRF09mbUzkue7xBbdjNyQDe+O2J07amXoF2lrRbElDH5u2nVByDyNVAiQf
+acy+QziREBXSF7ZoW9zmdZqUWDbzDoPBYbAxm901tbghfbVv+oTZ4/NE5VVIVGq+iwuHfe7C0VZd
+ONp1WI4WCYzQgLUxM0cDjIFaGcCGwnO0wafrpg/xWk+4g4SNcbNrSpirdbkw69q/NjnaTGv/OixH
+02nMp53ZOdr1fPZeSW9ePbfOdpDGhtc5jYrGPVvjE7bOeFrQ5tahQ0ex+i40Aad1ZQUM4K1VR1CX
+f+DDRDFXdzdOT9kUW/IwnSaTpbJy+o1cbCyYyUZCstn7ftjoBzc2o6/9t5WpjUbbrFVS4ThMYDuZ
+yXtjk5V6OzOHQJBWLCzYb+c9sB3vleNQyfU8Ps9lCI1N6PVzkYWGp/dHMu0iDW8n1++99pGBj82u
+34OF5R21EIlPJg2hMW/z0VMWuvtgsbE5LJ/6grI0uxS7DevSCpBit5Pr926tkNmfXRre+stCSyxc
+cDs+0tBfFo5zmPrCMTe5NPSUhRgSnqYRERZpOBb7MkE4kn30d6Ys1Ne+V/CUGYbhyYSgXy+e5ihF
+ZWR8QXp4LNBYCNAoPdf2mJ8fGwu1IENoutCUGORV8OW1dox14/4zGQnpVsW5DLXOXXdPTYvvVfVz
+XfuE03l0ybpILX7LMMvLxUjLuoile4dYCuFP9jTSGgMfsWSLXAtj7987Y+knXlxWbw9Xuvv0t43C
+RttiU99L3vMy0e4NNjYMIOLQHpL7UP5kr50BOyU3BiT8NmRjHipGOZtzC741oFhpIufZKUuXfNzC
+Y4uLzovTB2QuC/xGg8Jd4Fmz5RIXS3k8meUSM+OOYplC5tXMoMNTaOaRQ+efQWdkDM2YQ+efQWfZ
+e50phy7lm0FnZAvOmENnAHXNoDMjh2fLofPPoDOzBWfLofMESjLoPLMFJ8yh88+gs2YLzpJD559B
+58jhnTqHzj+DjkixOeTQpXwz6AiUOeTQubAoSwYdiVKbLIfOHpDsnQfUd1ji7mavVa/zzsDa8Y89
+o10K9vSeLatBgdubjYS/ck6iCB4rQXEuYV1MZ8uuEaHTeHoBT2eTxJJ77/GdrXjHkofFE80rG8uy
+GY80Ww2RDIa+zJR/l1z2+HwaS085PkfOSHDmXPjxZYPWS2ikOzJ4vLoUJvMxwA3m0yWd1+h68sRJ
+c+F5zX1adUQOT5NAFSIUhEixEMEgL9VZ9ubsEd33mYXZh+aiurtE3QQmu00eCjJm70/pMR6bK5uj
+yttKCkx2myAUxItbAmJ89nUnMkOgKaCxcBla7o3ZQ7DAZt1N2VWIGrHJfTMfQ/Ks+sKdf4jDoiVb
+0N/srTmSTIO3n5OePLle809hnMRxVjP3sl09vTY3iYfjzO44TI27SVq7ZqaAzi2nz63xTuy3ZqWF
+ywN7HPqrE5Pk8fkfXRA6zq6169C83PL4jnum08o7NW1ruH3g0aUxVdo/Bh465R0Db0xd8PzRPL6l
+IJkbOo+v6xohbsl5D+uW2g3OiXE2RewXz8YCTkEI3S+yZxGQJDPJIO3bHzNiLCBjZjKMeW+FTIEx
+98MQQjZmd/zm1bFAJ5L9NA8D4n3PP3UpYl3snk0EpS0GNWDxjno1ccXSjwDuPNz2Xtu2ONhgY2/M
+tetj7HmcEcGV7heWJ2/C1ofXbJD1as60B062BkGJch4zZGqw73vOnRFvM8w71y547Qejw3uL0R8Z
+htc6MEvOId68NJc9t1XujB1dDKtHcs+DRtauR+57ZsUaOVYOPdKLkp8H3UncFpqpNJ5d65Ig58t1
+vDOinBFEU+tj0KUwKa2RUCv+eZgIu1xd45B0GoNOrcwHT85dHCQBu10ZmgSCMuMcXfLMR8Z0tok8
+Mj5d4ieTYn4Zdn4eGf3MrnCdCkiK8+zS+Nkd2+zBwOGR4ZfkfoBN5++RMWiMPZzZbXHg6ZGxcJiQ
+ZsPXweQeGQ97H4a2MvvQDI+MW3RH+DS0sB4Zn/OUMA1tsgBh97kay0idwiODGWiBHplIGMQERdoH
+JudoOgxiR5osTdQnSmJn5FCWtRyroGiaMMpy/3AeOYnb16z/JHrbBs6Yq8NZnDqOoZmRs14xvWGG
+tpkMS5+e8qV/GCp0ITB9jIQuBGcLBuXVhQmdigTn1c0cu97HzEcft1uoABFLcp2XC9ROyeFC9QDy
+4opjHxXKEt4RWUZkV4jNh+nz4WynNxgZcfPOh5vt/LGw+XABNDanfDjiu5gtCTxEPlzoCNWZ8uFM
+PdmaETfjqMby4QJOBJ1TPpx3NNQ88+EsNxm5JrHNJx+O0NhYRty88+Fc52Xu+XC+tpjHtg56Uibb
+oPPMF6v5E1DomEhyxHAY3TJMTORYlMR0a/96lvR6MxLypje7OkFbGY8MnniHF9txGM/BvXE55Yy0
+M2uOPW1FX4Rm/otlk2aiiOdrX7e3IwY+VMSzy1YeprD5J+LQjNQQyxAmYqaMKOq3LM/vIGBs6sa5
+cgL5mOcyrD7dh04n9dTGAd+znnJBZPhcTgMm7QSeLRNovZJ2Jl6GblIM25l9GWIrHrLQ8zQtzzBr
+bMx+JHDQaWhr3z6nNeL4Ug4fFpYFqtLjBrVrRurtPDJSn77nmJEKjc0vI/Xpey4ZqeyCOKv/iORn
+pd1amTQjFdqZgm+65osFpPOH7A0TzhYLbCfMMdD2uD7P/C1YID6HpoYLMrJG3SCDSI8tw7VEwESE
+jba1JsPNGtHjmgpnkWJhInrsgwydChd0FvR8UuGMVaknw03ntwxIhZvWrpwsFc7zDKK5psIFnN4w
+p1Q4el5fgGoYSjEsZ/1yq23MIPhEeMyrswVIhDkR3lsfu5/bgWoEY/NyIGP2mscxhpPrMI2B/ZDh
+MJsLXtno5Wwu1BaOT+gCZvlpPjr3vNcQyc2OLvlThBEF7R87oHmAzumtca7kbLsWPf/2+JavPNRu
+Lndyw9JRJF5VXzZfN68qn2y5lDu4rSwqB5eV7dTl1WbvR0qCb7tnUHOlXLt7qrW4la2FChVGxN1r
+8SffjCeAFU629XOutK7Yk90Wb+7PrO4rWwrY1lr58d4r2e3OJ8MO7+ZjreN3JLsxq8ceQKVFvFT7
+2eu6uIAMuz7vDRSv1fYEipdqvztysSz38SV9kt3ORM4C1J53Rq6aNoA6r4vD6zE7Xhl2QtInw26h
+Vs96AmVqhxtnDqDW+/jiwknlh1ey26tfstuS5A1093zxwec+vvhp+7juBfTCB70nhzcOoNYMO6Za
+va7ZZ3WJHFhgfNMy8Uarm7lQ9fgyY4vp9arJ/FhdK4ZoMbXWG1ZN0QljvhdMRdSIItC3cFwEatkv
+5j4w5NapwQJaxaR9j6gSdOx/OHlN1v6ma2iZt9fE+x4rj6PEvWKuvFN7ygHxpG6bXy6+vhlvkrN1
+SbtHbvxe0Um9S86b5NymLpQXbuzQs0mzIQ1P79lyjwk4R9we1+dzldlY8HSgF26SS+Q8xxd471vQ
+ZSOhxhfmroGwKai9EPeMhEV6UMh06PXSCzov3y3c1e8COs3im2M23ex+mDDZdG52gJsXbrZsOtvQ
+tFy6oPNhJs+mc/MJancMeWF5imw6J3fCXLq5ZD4GbmNH5p5N5+W1nm82nVsgyQQnhITMpvO1K+eW
+Tee2T+O69zpTNp1bLp3nzsjU2XRufhb7+ZbzyKbzzBmZazZdqHOuZs6mMypbcuncdkVny6ZzE0aR
++Lyz6dy6ZO5Wzyubzi2XbuzGnJmz6dzmT1svc8ymc2uK7vDOM5vOTR0cyxmZOZtuSoxNmE3nj7F5
+ZdOFyrKZOZsufI7VLNl0bpqnI7d6Dtl0bgzHfm/CPLLp3HZLkMbmm01nbUDPpfO2XqfNpnObZ6+d
+kemz6cwZMrdWvOXLtNl0bsjwuC1rhmw6t1w6z0yuqbPp3AZkauNeSil2alYDkOyMVFTnxbvPg/cA
+FcM/QcxID4s5rKSpE59CcAurdjGf++r8tYt53Vfndludi3YRDk+BN9taiZR4FD3vhQtSLMKRQGWI
+UAJuorWtHN+r6jy75BZp79Op0NLH3iVndMd+CA0gbJdMCzMch/HBkxJm9Y5lctktIpe9568Du0hw
+iT4ac4K52pXOi+6mylmzXnPnHg8TViUPe81dJITH+GDma+7oTXkBF3eFS6TzCZAIG5882zV3Zhan
+z0V3M19zN5lHcdpr7tw8imMX3U2Wq1Qev+bOeRK460V3k28e8dvXKctd7FOec9U/nFuexfbaeajk
+1+DMokgcBreWmDnvzD8WIxKKQrev494hNaFjrQ/ncQw/Xk/nEftrj1QJzjD0DuIIm5WGiJkl+dWe
+ZGhVoL0p2fuGLesGCPDI8XwiKLMLuqCzobz2ezBdLRt6Jr2joS7nFw11Oc9oqMuQ0VABgc1nX6EC
+oYIzH5Mzb4WQVhzHgbvMfsh2JhF5HpFdpJ3pVqCjFUuG3bS57JbGvM8WDHEDuzOx1uWAYijb9JfS
+4U8FxMbK/skr3hEBYxHd0BgXKjLcIrs8UflTWSWonOi+Vx8lArW1pDOCGspSQfuV4Vx/mP0UqLqH
+yEy56U2kSbjpEdbct7ndYHjTcyQyTLf2B5+hLhoKznxcX53VDiibpxTPtFtN2gmTzxmUwe04onjK
+3hDfxbo9sWLCi3gcC8QtkWHqHV7UvVbHEhlWvgMzU0IuwyluuHPLr7z32yKf6oa7edxbHXzDXSht
+fOYb7szMR/c77iZbPl7nFU9xU95c8pLsd9zNMCpnXtJk19JNccNdJOQhOdPdcBf2VHMMUpkdgeQO
+7mkCNlwRWF94dc2FtZw9GD6xtr7QWJzICPXIfJxDYu3Tt5ndPv05V7SdcN4s35grbGfWxFrSCp51
+M3tiLfbG+1y403OLnhwijek2RH67WxKTRYdxLMOMyzK8m9Kv5Xrvm/fBMpMmMb2qxNbykmIeaUxe
+qLzzN9vpeX1hDfe7Kc1211V5F8pNHSaJ6VUltvs87EpM9PQ34O12pVca08rmjTdjDqEY2rwK2KmQ
+iW3hFMNyNkMUQzuUcjbwzu9QiuG9QzF03JQ3aY5r6e7D84wTCyuwnwPvkxEWYBb57w==
+	]]>
+	<![CDATA[
+	2DgxFipZPMTRVNCU5NBhps9xdZ6F7OGcDHm34PTXPRpxsOSSvHnluN67Zbh6ZT376Wjm6mVytdeM
+Gzw9zUwpq+o2C2ufJuldbefvKw+1+6vKQ1XdKe5JVwflUrZZLpdyhxjGednXBU+8Y8eY5l1y3MN2
+3e88WvPE7ReFPXpf/lY4XzuzkpItHy613jz1SsITPyLx1fhGrOeVhuea+6enprVynkCZ2lXp3Ga/
+OO5hs2aJOYH+8LvmLiNbgNpT0yJxdbCWGhhgnalpwt3H0brHPWwLCc/UNHX0g7Uk4Wl3pVkQvLH+
+deEBVFokt+t55cM9egKNxAHBX94Jh0ytd3XlCXT5SPloeQFVTKBUVtrT8M7vvIFWTx53PdFru7zQ
+ChTmBcCej80qLE0NPPmm0flayHrrjnoa5x+rKTwdhWpRSJ7RepqYPJJclM4TI1uwNuo4vSp+fuId
+N2nnGTZJ/Jap8fPlzpZ7YePH/GTzY8V5VmdwyJB3StK3f5ci4Ts1USiMfaPLwvkrM4dWmV1yBFZ5
++WBDeJLOVmJhp47OizeeJgqt8s9Kmyi0yicrzTNC0366aSh66k0WpeUZ21OZJGQzqEsOW2yGVMeg
+KC16FkGoVEDvA28mXC8+cVo7tDfjdo7dtM72xpgVuflrHqbES9V/+zKUD3bmU+MsGKvObd/6pTqH
+XR4Y2tPs/rGX6hzObYQ5N1fv1OdaT+RZRu+odxbgzIfQYg5g2HyxQKsFG/OO0grjH3MEjTS4nvMG
+yvrCkf+Yw3KYBjeal43s6Q6e2Blcc3BQZ9TNZIdd4SFk3oddmQ4aPcMu2KtCT4awBRDsBp+6QPUR
+iyXund3mIxzDJZIZO4mfheF8zjkYO39sthyrIOXN4o2lJ1B5dUrxPOcghDZuv1/Mwe8nTgU058/O
+713z90OnAgbe5TI+fx6ZKSubN5m5EcNNNviWmfCNee+sR+ITNxZ4+e8kGAu83yd8v7h5YoyfJ8YE
+z8bG0oXtO7zTZgGG1Q6td6VNngUYNgdw/FQNryZmuVHPrvVNmgUYNgeQcv5pswCDbSiP+5EnygJ0
+Z3XjOYB+cbBeMzT5jXrOWIXJsgDD5gD65Fh5omPyG/VcbeTQWYBhcwC9bGStP2OjcmhPIS/lm/JG
+tgkv5fO6LWu+l/L5exXmdSlfJDzTmOFSPtuq/GOX8hHv6LQ34IW+lI/Oi98NePO4lA90fryWb054
+8gq+mPz+ymku5XPzKmCnjoQnL935OszZUPZb/cxbzGa718/I3nO91W/iTK65nQ01zb1+XkNbmT3a
+9mAeZ0NNcq+fb9adU0+eMh1xDmdDhbrXL0R+5Rzu9TOw45rYNEbJU97r53+rXyQeQmXXseNzr99E
+mVxT3+tnpwjnrX6OSJWp7/XzH5rf/ZWT3Ovn2ZF53ABi3OvnP6BIiHTEmQKgyTQFnGo+QTqi30VY
+kXjomDPfe/38V6+mjc98r5+/oLNbSdPf62eZK5db/aY+gcpxr583WVANNiB4KuS9fkFR0PO5128+
+Oe9B9/r5t+K4j2/qe/1srfjFXM10r59nOBnZA/HNSJ3gXj//DRX9pryxPNwJ7/XzS0+57KLOP6cs
+MZ9b/Rx5r1Pf6+e/T0OyBuZwr5+P5XSfSXhlpE56r59rdoFxq5/BLWfIezCOfA7QLWe/1y/02p/p
+Xj8zHdFtd3iq+/gmPsXD6z6+2fMerLf6zZLNYb3Xz8XKtWwRh4m2DXOvn39gq90HO/29fv7neRj3
+8sx4r5+ecuUen2HJGJrpXr9APjaXe/285pTe6jeX+/gCgzTC3cc3w2E6ZkT3HO71S/ne6jfR6Q3j
+9/oFX8XnyWGmudfPJ9mCXUihXTmPe/1cyMtyq99sWWlh1RzTDzPbvX7+ao6ZWT/bvX4Gtl0TNaa4
+j881e3rSvNfp7vVzaSXk3eiT3Ovn34p3zJXLvX5TJ8PTnMTZ7/Xzv9UPoczjXr8t31v9CB+bw71+
+/oFOOPvzuNfP32ynGJv9Xj+jX+FW5ZT3+k1rV052r58HD9Ru9ZtP9CDpks+tfvbT5qe/189fMYzE
+53Ovn39CrJtEnuZePy9U0lv9fPWxCe71848HNjyKM97rN7kOM829fl4zSW/1C5ldG3ivX4h4yznc
+6+cvHAwPvCkejoTsmI52JPh0mcqF8YgP07FLdZgVfkn+zDlcu757mAGB9/a0RQcfE9IXdh/Wsm3Z
+J76sMcSEMRsXgpA0AT0FqmB1djsjiDAjLJZ4TI5imdzKcZY/kpf06kcDVeUGxdjqu3qey8TXlvnb
+Y7EoSqnBx36uN6qv7CkFeXX7celhIbY/TMaKtYvcwv2LtLZ0edMrRuLxz+7l0Yry0c9Il0ffr/nP
+1tH7zuePk49D5VKWT572vm8u2f7h2+XHebtzvZs7Ht287iYTr6/lVPLnvfjz9Osstf7WTz3sDNX4
+ZWJFVfml2EJP6eXizNLHevLhqHkDGJNTx4mt76WvI6YV71ZUdXvtLLb6vHsc40qnndR6U9hhasz2
+FlO7uq0xu4u9E2b39ORDVdvbGXX0sbUyWEmfNHDgMS3Tcuu7mtosnDzilMRI0htgrHqTf1UH7weL
+TO5UcWVI2ryQ/NKtwbDyUCse1TaLm03zCkh6j+BK6fvCgSyCqkh8RemwwuXH9dK3utOVTmK3J4cp
+c6zOkY5+ZJdWl+N3Z0uF9U4pfna5e7Dy43J/U5CXj6WUkRwK0/RUzeSPln8CWaRqJCdxPxNT2885
+TOC8ANFyqtqVrbJ1+fyId6yERtQJzd9aModmSh9D7tNM2/zK2nKPE6q3pe+bndxwtZKShUauVOX2
+dqDs+GDn7frqpLgn/ThJyeLmdk1eumiVnw8W98hIudJ9qkqXNTnUbWv3NoH7K4lUJR0fReK1xN7+
+Plt9Wdsot+s5FienW21+fstM7u4zw73utdJMrv6dQRm/hBERGXwbBOZm75Pfvl7Iks0anbMvrhBT
+iMmJQpL8BIzt9HC9iGspUgDL+eIbfu5k6M/ngZIm3/iljY0ftdfk4yHz9rLzvrN+FFOh34e0o7Sb
+aab7w3iwan1QjjciceNR2vromm0ZD7LWB++bb8YDxvIgs7T/oT84SZKRsrtHC3VSRmTlScpSffcl
+2zSqZ6wP+msMluU0kSCeMJiw9MXuSUcc/uRo242XeF1v4DxFqkTibKPP4jkd5xmD+SwBsSTwfpjz
+LG2nKZWxnXOGHBrPNvdOyU+t2ebDI0vMFCZ3X0vlji8/eXh6lSZPuaS01jIxdpWlUJjkUoHhOpfx
+alpOvuysMzdL1qUJLJMyVGJhjluvGueH9nJmezD782iRsfSQzS0ONlLX66q0dS2cFPPPrQS1K0tc
+8uEyptHv/SNX/OodDYqHt7c/TPLikqPWpz7wWwupcJW9TdQEbyl1c5WHfZaSfaV5KpJvkThX6Vxz
+Wuno8YUsdq6arL9q37h3EZsQaROvDzvY4kOW5Khwrx0w3cm7r6MLre0fyTuD2h4466rkfqy3fhqP
+hFT15m4Px9KwjOXHbayMfGUdDyu+KHWy76vFs+bbUeVwP3ZpumoY/UDHsuGjW7Z54HV2XOLjo31F
+B/qco+t8mbsWSG/55fVHUftWqbeNerxW7+ar6OhNJF48LV891yqdhWbx4upppdrI7NyaGgIV5Xb1
+G/p9Vjak75pD+jpl7+pzDTAWS3/8vIulb16qsfTx7V0sefKQQIl8EEuNQJ6BnrsXSye3r2LJdmcr
+lumeP8VSzaxsk9egHxB/KrG1cpv3CTJSYGFFwjJXjSho8bKvVQLOCD/vwb45ExJMbpjA6X4d1qrc
+cQG+7a1gTOg3HiuJzue9JFm46CwkP+HjvpfV+OJO7JnMKdqV5WyapNBwz6ON/Vz7bpil89ZOr6WI
+psQvrVcP3CxM0HRPDumyNz7wwbUWfb6VT5JFAfMCpPTMrhbzwK63NlN6lw8pg0C+iWM5BBLI3+yV
+f3wWW1zp4XpbExNbRwwjNg6RvA5ZK9MrfUswOe+nyOAIxrQRYmb9U1FT1XbLaVpWX9jvw899WgUU
+4/ufpc5Ct8buZWosNmFte2/7gnfT7yz7+8sWrXBLfBqYOuq48/LrkUuCHsG9fvEHqW0uzbG77GON
+bbyn7onwJ2+wq6VWRfP2ONw/uePCK8cc7JYzbOOodciXCr1NNx2VYRLZdUOhPbG5b4iKOJSQXGUk
+SLBe8U8pluZqJ6Qgltw4WUPC3kdyvoilzheW8ellLFPkt/CjBRR/txdLqmo6lo79WEHJfeOkaeVs
+M4U0Hdfvra4+1b6xZt5YsDvV+o/q5073O/dj52bl4r54tf4zUdl/lA6Kl6PEws7Gdi1raGHfpFly
+v3fuI95L262uZc0H6wDrBrTcri2rAO/ue6e3p97XXtN7i8XT942j4lVFWKq8nQ8uiCY0iD2vVDQN
+dfNhEQAcd5ExbzstPtcBu0A+r7wt9xfX+HKlAQNvvvoPV7OR9QF3VWjxUnBad7hygNdyK/S0CO1k
+iOMu3kKcsQgwZlDplk7PdoAviuIPEzKsyiBUE8hP8rSQuebrKsr9p4/XSvbih1p+2+w2JkI6X1Rj
+lRAonyuNbV2/rlYd9gLhmzTmKkUWrHbWBtiBKePYGViVfEFaXDu62FmrKu3SZyJxXt07a7M738Vc
+sbL/1R6AbGJL2loUKm1gKRdDXJUrWWGv+EXmeTxrYBJ8h8U2WBYWfG+v4Vkh8kJqa7Qccxv6lAOH
+2Q8/9KkJDbW+CYbuOvDt9a1lK6tHYWvvjcn5xxipk42urixuxNLf/SNko0eoEBzCg4yKzPMSVIMd
+4LSrpXQsU8i82JUEBnny1uc21RUs5xbNuNgdFB+Jeyz2WdjMjbJzc7i5X3sdXsWqP6TTD9Atwy72
+GXhbJB5iwDPzNrJbHTRgz+ESRwfMaWGk6ZHvA9dVTuJg5zXJGjO7Wao41hrhlrOx9RBrTfMqzMLW
+Q8jwCWjMkOKTQ8Z7Rv6A0hJKis2itLghWr8lMxjVkwzXSWjAYYS90sp8JtlHirmurBlpzKmtgaY0
+PV9B2+Dm2wx1cdgG5LVyKcuAfKnelu5Piuk+s1Nsnp/UKtsp8aCY7q2tVB5qw2fidtt5u+qvV9Xn
+xqnYabwsVUb1s9OdnDpcKv044S5r8qK4ZTrl1kfvW+lSVlBvuJXt1V0zk4sejpfQDyHLLeGKp44e
+3Un4A+wzaXFQTbUfPopXN7fquiKrnzD62Ef+e+/iqFqvr2SrD62FD4J3ywzEe88Y0wsaAseV7tl9
+26jDQl5aAk3i+wnnAJTl8suTmx5FfOMOdWJwoh09NgXQW66SzW7cAj9/ZnfWDz4vwuowBKhdiZhU
+e4rEZ1QcQ/HzSDys7J5AexrDNt2xmhbfYcc8oxSbSFNyFaMzgreiHNb+XPQHf8gwLxPbCZPz17la
+4rgncWYxzXCbgeB9eitpEmIn8sXZgcd5+wBcLfG9rbXy44G+0DYvnEgnLuDSXWvksw==
+	]]>
+	<![CDATA[
+	s7X9nl97PjuWQXRIOwBlT9oogaBYPCEFGxuZ4QZIkN0jEDyXRzu54fZhcU+8zoK4ubmEn0xtbblX
+WasstiTmj8iXKRkAngn5R8zVsPJlVsj9crn0udJ9qmTzK4NIfCLR+v+vfJlQslG5HzBg/+ECh+kv
++TtjIvE5TrJhz69kuplCx5RsOo3NINTXD5cqT5Xd3c1P4Cv8t9vAgfN7zfSMKpR1caEXboLlNSWJ
+a3Gw07vBQkEmOkz45TXl4tLyLOZPaK58bAYaCzFcK42FWF5TjhmgTLK8phy4lcZCLK+wiwu3re7t
+uaIu23/pygWHLr2TWOohsRNLdYRaLP3aOsCfK7gr+Iw+vBPcN1lH595pLPnjraDtFL62+FjmQL43
+XX+RuMP5N5Prz0urw13R+Xrb3RS6SHzeforQHpLJNlcctO/GZP+8jYxadGTufgq3gWt87E8ZMZoN
+FYlP6Yqc0Qc7tdt/XJ+ewj82DcXrkCPxPzzxNuvV35T4gz5YT/vN4R+j4UZT+ce6fbV2tS3cEZOk
+Ji+M8mFtFbdVTk5qdVvnK4lyO/aYDLvEqXijlxW0pVsaMKSba8bJxmEXGruiDMsf+WclJG/71mgM
+v3/dPl4tX9LoFho3PrGg375YfSpeXf98CWklkW80HnM9TT1ExAlKD8SekNqKtdfPzirQWLFT/xli
+jZFvJHpyENt81gN269+5EFo0rv0/OvFGzvsfnXgy7ZH4H554Mu3kpok/OfFk2kPt8swy8Vok5B+e
++An2+GaYeDLtGKnyRyeeTDbx9P7JiQ+lwfpPvKbaD7dT/iHTBk8mQdNGdD7duNFGkLSREtu3Tu2n
+vGrEWqM5cyQ6bQgznj+RskchEimX2rystnTFuGnLHyCSdOPw1pSkXPmqIZjdJGV48c0xaQBX5eaP
+uLOJUePs26KFLj9wB5YRkLLY5v2XYZ9e265xIXN+b3EGg/2yLPZqzib4/UeziUv7DS80VlWLBKy9
+rnDJr1IeA8ET7O7LO4N0kNTK6t+rpAwx9rmQwoMqRSMutTVmINEg+zU2ZcTSr+7crtYJWWD0PcZO
+nvVoUH9i+7FjWRQYsAo82bhZyLie5tmyptc71yfY0QV8cG+/3yZhzstdrJer0kuM1NL9o7EqPxKN
+pYsncnaHsOu430i/zIFgbBQz0xtiwuBxWV9XSbwZSl40e2MlPnIqPUXBDq95SCgS4huxHzoShJyJ
+BOzPp/MUdYqCyuDSQMGTFQWjx1MDBXfEd2FBQjoEEvid80RCQ0F9+9SGgrWBzkso0JhGY9qUBCOB
+HlpIlk8peWigYO85u/Dz2p8ONCsJmQ+jEXH+9FNDAjdirUhonh570YF2mhTFIvd+7iAkncb8myDh
+015NhGiAWknJWZoAZG2t+q8HGIvfiliBSd5NzdIHQpDGqpyuidLdfSbEskYO49UEOR53hj7QJDSN
+W05HVBNRJdHHxviTlS7DrW5nAxaqhAYQY5M2YaXK6ThMwkqX1ibCzkbCSpV6AxRjz169cDZhMkrv
+2dhe++zqDazSQVg8igkrXU5DVAlPqtT9ycFNmHTpg0qPBa7pMCZdMnuVy4Zx213XDippEh+5o9Co
+9+ysF47GfEaVnJzzOWks6UVjYek8adKYSSBIY+FXfNIqjCcgEAuNJa00NtUwTBpz0HloGkt60ViY
+PlAaS4bgfbGVytO51gQ3eLH3YdWf8xkS2QcTqyZdTtkHu0SeZjZWrVTpQREokX1mY9WNLkMwLrOB
+6SUyMbmUn0pOM82sedKO1GbcHimirExsd5qxhXJxwbANXVJarG9b06uEyxWaT7VaLBClLKlnU531
+tGyqu88UzUpbcuQRgck8YrjkzsoRtV7RjqVZYnrns7bEn5tvz8Qfa3YtMVK1jNT6d8Hu/1vNtc9e
+drnkwwWLCftpLe+10UTD/HWodfn+NGsx0a8318rF6+X1Lkl0jNBUMaLwip1Ga7nyUHtIWCNCHOmP
+9g9b+iNrmFl1cvIOYom3nqE6joS9FZNOiOZNU7yMVD/rkQpjqXdlkvhkjVVYaz1s3xvIurX6RfZX
+1vFALtvQ8Lzb5VX5INde3Nlhm9v7MptmL9b5Yvv2wDA9ZeraKz3we9q80E3E0sXNiUFZ1L1OUIlr
+Nmt/gEYFJtItbgDl9OJ5MmF4nAqba4s7W9xrs0YPM6CnpxxffvMYDdXY3NIJkUuyzaWvXe1qDfvQ
+uPZoDxuTNRLHPFtqKN99akm7umfDhpGLzIZ2zpUJVgd6LOU+3ha2MKc4Z/TxiYxvS96t45Zno4/Z
+vHmYoXUw4T6/h9qJtQaR6igQyVk3zwxzWFk9MFwrV/TKCB3LG+TAbxjG+w6bfh/U8EKUPHPQ2Nzh
+kvmlXcx9EzCBsQg93Fnll3keZi29X8N81WdC7OTcHme+HMvusndVNn39xcE78jHO9DbbPL9eh5mu
+77B7eflUOzVZZBNGSmTSOlfSWgazISkeInEyW2x65SNpoWQ6DM2L0/d6oCeJbN4L2jomd9MucymN
+65TZdZK7SONhXvXc1bOe3jMgr/T7+xZlLjRx+nMhS7Ndl+SvIebx5chPQuzat5/KqjYq5BtGZqfu
+TwbaQet2L6P9PBK0Jt6u14ZaorK4zxiJys+wcoaynmSpJWtqqZr6CEi+pi2Ls75U3tQflTPmO7aM
+zf2c+YBfWn8v6g9OWePBi+aN3d1cNctQVpqwd8tp85EVMmZxglheBfJ6StF8zufBzxE8gAWJP/nt
+6xj8PNsx234l551BWS1NI4hQqiolwkjQFVkg52+QExag0mkOGUAaAHwvwc9r0uwqnZzc2SNvJLkT
+frCIT1MAIAtM9v4oY8HYDx0KcSo/ZCq5+sby2nt35bq2URV+mnae5hPcvTu3Hl6jn2BjuBVl6GG3
+bLYXic/cos3tnTwonMuF3drOinJV2W9txrSz1GBcd6xOv1ecJZc92Xld1PPg64KB77qVvBqn5BCG
+tMbRGtc5jewbdwzbONpPwrdHVs97zTVeuC15n4PZatR5/VtLIE1oU/t5QVrMkCNm4OddTnv385HR
+v72Y1NbgVraPtoxV+dniLY9eYvyrluR+/B3XxvL5JVliTZSX5Fv5Q6qdljqFxYJF9zDupXZkQkf0
+TGnz1JjhXdYA2tSIZfjCAG/bwYTuOqt/a5mnCTQ1MTj8KYz1RhzeROK11eTWev4ms3Bc+3Ecl41Z
+zYdNNQ+RaE60i9lSzUMkmoNEnjXVPESiORnLbKnmIRLNkcYmTzUv/p+tSL5QkKIFsVCI5i5GHUU9
+Vdvv7W40HVmP5Ir7LHvdbfVqqqJcKf8OK73m6EvpDqNr0Vzxsry/XxArSrPXUqLkQCfxh0kEaa2X
+Gt1az22yKdNE0SlV3uTdz73Fi8165Y2533Iq6kl+b5OkiNN0xQ2aCpn+aH9gxFMWz0G4xGTHSizD
+HHOE6DxP4aHa7IP09bCR+VHr5W95pmVV7rQw7K3NRjHdPznYOZQHW4W9jdtsrfcg3FTVpwcGdN37
+K3J8D5n68cMIQfmb5mCHRKa+gOM7wI91zH8/g1Evv7gc7BB3rjZluFMgmrApwGzH4NSXvp4oy1nZ
+vKfnXBiqf0bTzMWnAf40DnXBdad9S1C+oww+iUqwqol8dgHd8HtpQyUoZ3G3cC9rvJgzlPsnWFT9
+kk74QsKiF7QSiTX9wdqqZWVZDu/Z2gEoFvFvsFd4VMtaHjyPXnbM5WXRCyzgd9eImyhphby7Y1U8
+Xqywd2um4vECCLwGFrB7pAuA3VMGZXdKE9a71xzhc1ZxBIYHEe8aqzjbzxhXKuA5b3SpnB1lqQ6w
+snk3gJ8XDDpFWPho4c872iysly7V3LjkUjapH4OzT2YyZdVmwH6zhS+GFSlOfmgKlPuLnFt7kfj0
+LV4zLjbmj/JH/rBfvCp2b6nCUHpcfcFNeXLGTfPOOJ3lijfI64d1fhtHaYteQCVf4yJLVYLqUyVJ
+v9UXbqiaACi/JL4bPL4bTTayi0skB/mmTW3jXaQ6ANUkP6+z6OVgDbM/Y0i5jFV7/KxzFuGP7B/D
+F+mjd0EXGg+i5Ric7eva3qQ6HJ78Sz80jcu8fOpow0qNw8ccsfih38VV+q36dJCi3yz9Hr7zpEw/
+aMvaG+nha69TeYsPQIzubGzfCcXDO2bRynU9jqgL4cegsVtSvDwCTqvcVRZboypg7Hn34m7t+bSX
+IGeDlZId9WwnN5T2SlUme7X+cNTd2u3c3D0V96RYwwwwMGIwJnDRAGd8GVATqb1wtmyYSAPdqsnS
+zR5NwxcF6gkmJ4KR88DYvaWfW4QzmuwP3rhhCHOkB57v4IVOWTJleNDWA+WW7seX7zGOE470B4cJ
+oho5jw+jgR94dlhf6zKwT3I2mqbegcVkKB62k8P6ZaZysNFjxm0nmBxN8dhc1cd3ktKcwMTrgsNA
+Ve4ko50s1l/DHeATU/lRNGYGZpPZNlGw/Q+Zs14463DwOGjHOA7qxCJul6ovohEicG7zM9KDDDMk
+ykBzNsaWm4XDsUCFYWJgNHE2HqiwuksCTPV4it7qeDxFhl7RoAVJcgn5nrdFVEiLsXhpqeITklHK
+HZu73mztbpc1j9vTuByqPjQYL9feuq4S+kaVd4usCL3s5lsvu1dz7dNuyjx3i6i+tpUztklubpHT
+zSy/SAEiCGikwCbnESxBTmNyD5Yg60qfl6n2M5MzB0uwfQMJL1YkEJe0FifwYEUB9MYWqVPozxgs
+YWyuhHWlO7eZMgYSNKAECdqUWJHggYLNoVu8CGiwYSNGttfOhrMFS6BjamWmuBswHxOeDZBQ/+Am
+Bp/JWfqAB6CtfK/OsiLIRQP+fYBV6T8Mekj6DKgEPT+DTuBZhkFO4g3sQyTu08T1Wm5KotIaeNlh
+jAC2qZpAh27CXN3+a5tyfufqRtmdDNuEewPycHU2DoOaQsq1D14UEYmPYeIolQ5swtqHsQau2Yxj
+OjVZaZ2N+saJ2QT/2GEL1iZe8mGIytEHErxqNPG+mZtlbRAVyg0PkXhooZdZ2mdpqOnC7l5Jb0Ja
+XH1U+W9Lvd3Sd1KrV/vJmhiTFuPCSeWHtebRwmogjfmNavc6YeE6NhoLixjQDt0JxItII3Enme6+
+C04SmWy5gkrqJBBtVYYext7STm7y5Wqjsb1MjZlpGHvSEetBY2FX/N72BRfQB3UrxxoN7AnD7PWG
+VSLj6b7BROXXh8Z7KuXZB10ie/VCa6LPTkZUjj4AlOZSPjPTim9mNrP+qESJ7Mu4mlJ5Kq5DjGyR
+TZCUQm1VOlIP2NRnfgUNgxfdQDzumptUpv8ktXXWoR4S3R1IXPLoXdLPftUvmkcDWDOaATYxuTTP
+lpinITDa6afiJj0BGzTYRxV+lrP6a7Wc4d23HlAN4vTVPIz6MGl9JA+Ns6QPradUg+AxTqk+tJ5S
+DdLAOO/3MGe3ct8tUByed/RwnliP4Abe1zCOwbYewA3syDiA+yRLjB1kD/QgZFzlSA==
+	]]>
+	<![CDATA[
+	kCes5h2lnvct8dzaNiwBxO25tmMAtLimmQ3p4x61qoG8kCLOc9rR2Nv7iLZzVnvj/Jo0SuS+sTO4
+96pqroxkRkCyucpYd9C2d9YnPlo5Pn65oWGOc8m92saULbq1F4lzyfOjTXODQByeLSm7zw+F9+Ll
+aKldfWidoS/FEjvyw+r4vX/hja1DwXoM9nbeIJXbjDYvXOW8jAziNqcT/i2DkQdoOd6yupvolkQm
+9PAbb3wTaAPV9S88VP8hox2N3SQT/5Azrk4WHxi9nQcLtXE/uBfDl/nAWx9UPpf0fcGfouEilDzP
+Mtd4clDwjfPs8WeL84dfTp4iUp/h4/4W3QjPrPHNdnw3v3z8LmCp4NKf89qPm/tyJVVI1mrV4xtL
+VI65/60lBlGMHHxpTKH2mtSOIgf2cUB8tCm90s030k4Wh4H90XcqDO+atjEH7Ii64laLm30bO7oU
+tOCEtcQ3wSzhYzsZkhWE1sgDLLkbVd/vy2thZGBjPLpeZga2w5NLWFMZWVjO5F36/gtwrxRlXHqX
+nzUeuVXOUM/c86DxSbftbIyLMbcOHVsYONnHZO+VJHkVWC2+7DpRMDYPNb4CnCqrMSnCiUCH0dx8
+u6cMjWCwhE3QLQwSgjb4P1uR9UgcdwJfq92WdRcwEo9DyaUyHPWxgvhaUt7b3aP6b0WNsFH6HwP/
+4WdejrJcIcqJIvwQsfSoEUkMfr3zDCMko0fdSPw1V1SHlXZz2O516+rv6BoW3R0fneD+IvkxycP1
+aOLfr04XHmfqw6HaboyGyiCJ+5QIR62P1Wp+tDstVenSOlw0t98dmk/xY/i7r9CniY/hsL+Wy/VH
+aifbU99zrWZO6SiIlEGOzbK5ZDR3CUC77/YWftU7I70JLB+stZoeVbv1L62m1kdaN/1fMe6mqtSH
+7V9Ks/f11esOCAq6g8XQo25OMOrmf82o//nnn+w/PBksx8DKAeoNPWLvui5DJpX/68bMyrKcY7gc
+x2XU1ltm8Ls7rP+bmWTa4bXwSCCV/3uQ0O5+Dpr1vkJpHbo76NebyiCnl4dGQsALLpgw3/jvQMeg
+12r34V920BupTeUNMKJku8owV7mqGA8zTLY1bIVfH9prEywS443/MFYIM+yp2XDsQO/2WqvXpKMK
+HvD4O//hITNZoZBlo6qcl5gQY9YJeO2Xog6gk2HGPP5OevZhsb7DCh7I5c3u69VHe1Clsj7MOMZe
+0afuer8SXYuaKhDUBSWLeQUlCB5p78O/CBMtwr+7fyKjyDf80z9HkWtvnUlrHJoWCq/sq2/rVEkD
+CL/hxwF8+QlF/0RZJnocfXxmoi2EfhEhVVoRKZpIRu9ujW6w0Qo8Oo0wWY6RZV6IMlmZZzhJgi8F
+Mc+IPHxhWY4t4KM8w8oSAMxy5N9dXYPPUfg8I2c5USpE+XwhW+DlQvQrwotCViyIUb4gZ8W8zEaP
+IrwgZ/N5QYgKDJtl8hKHZRyTFSVRIPU4QcYikc3m5UIhKrD5rAy0Sl5lshIrclGBE7OsxJLmWA6+
+yjJ5tcCLpDV4QxTYqMBL0COWlLFCVioweVKWZyTyKiNlRZHPR3mZy/Icx0MZJyM0FusVsgxXIGUF
+MSsJoAQLPJ9l2Dx9F5YRy0jwLpvlZQlhcHk+y8pCgXRPlPM4Mk6CdzkJRoHwBZaAELPwAg89zmdZ
+Pp8n1disDB0VGBiNVk0CCLIIEAqFrJyXySgQZQUZUQz4FEgJl4URQq18HjDHcdq4uAJ0EyeC5aU8
+Kctn82yhQOoJHEtQPDZhR5E3d7LMa2sPF8TlB6zsq9+hRNp/ks1NwtuavW5XaYIgyDRH6q/6cKSG
+4u3+7/+/yfP69eEHz4iSP2fyYG8JoF/yP+Agzi/GI1bIZ4HAeSB5WHlJfK0AvIfhLN0vtnoN5bTx
+E5B+XIeyf7V+OunPCX+o1ruDTn2oPCU0MEIagGD7T0lL+6QeKEdfNrwUjSnEdm2PzAI7CxeFiVi4
+jU2HkhEiFwQAmKZgsmkHDIaIAEsfDL5jcECTjVuYosHZTb5jciyXMsurH5HbSDdyHmpwTODgJkaY
+EEC6U7UZOMtTtBk8sdY2Ua6yPEgflGYSkxdw3owyqQACVoDp4mSUZfAFHhHpC0iG6pJZ0ASBx2Jt
+2SzjJA6+iHmzIbNEBwfv6WUCKyGUqNEQSl2QRCY0o6AZMbpkVtK7rbczPrZyZA+o6CQcFQnBVJTN
+i7MtQ34yVW1yANxk5DDpMtZn2rqMXcqmW8bsfJbcBMydSfN5CXvPC3+Gr7OTrfiRrmfLvMRSPZtj
+xQLRs2UGdFAGNFBBQs1a5ERYMaB3CzLDGX+d2jYnguIHuiGIT04ia10ENZEFndgow9kFZbfAw4oC
+1VQAHZSU6fUkWG6o9B/pjVkLYJnKoCXiiywjWyqZrf/VFf/qimF0RSmA/c6iK4qgw4HlBwtEkHhN
+VwT2xMvz1RU1MGkEgu3/IaYiziBEkMNQQ59u2+B/d0U702DRPQBckQEL85//BhYy+MtC/rKQMCwk
+QNr+ZSE6C5EC1UQbCyHuQk9lZXanIDUJUKeXhGxBYnnNKuF50SxCzx5YjIwIHAXQJAsCr7nOGIaT
+7WXO5v6qIX95SEgeEiBcZ+EheZBrPAtWIBhIMuUh+TyIOGG+PEQDk0YgpP0/xEMCzDXZX+VwaBl/
+ngP81SL+coAwHCAfIBv/cgCdA+QDPWZhtIg5bzByYIpwEtmvY4EdsGiykDJZlMkuGZRLUSyBhnHf
+TABgogglebBcCsAyCmxWYoDvlIGNgFHC5i1llLVwArZfAL4jFqAtiQUs5wukdSkvFiwlMpcVGI4n
+bk+tjLgrJeB66PcUBKiOLk2eR+8qI9JtR6OEOj5lSbLWAr4ogZZotmSUWOCZZXqviH9UKshmz3mh
+AHhBF645Zl7kAR4vW8eM/j+JY1iCLVHAF8BuY9i8RLYniWsQCliOgyoyAxYd4LFMdmdZCXc/eeDG
+dF8XbDtWBh7NywJYjHSXFF8VJJHWY8gOo6U5+MLL0Aj0QZYYAC2DDABzkZRIeeLvlen0Ikgmy4sy
+7hsDEYmipG0SM3mBI/umBZbuiMK7QGJ5sr8s5nmy+4kjR4NVYHjAK6j6WALow1popsow6dD/vIC7
+xkwet2olhImRErKM7RewLbK7CmViATAmsOir08bE0i1agZFBKImcVsbxQKQCy2YLAk4XjgAllsDy
+2bwkUEc3n8fdYegEC7hDkIA99JizSDAMhYgIxW1vFnomc4LWC05gtTIuL2silJV47JkM5Af1eEGE
+fiEuOJivAot0oe+Dc4AxnnjScVudpdvqMIWwBLEt4C8FRsB6QpYpFGj7fJY4LbFM4qjUxrGxWATr
+kJVxSDhIoAiBy2fzuNKBUqEp+CJwMt2OBpC8kIWVJpJaElAaAQlYIS/KgFfiQ+D5PJAzvsrjJhZH
+aIoX4VUByxDpsKTIixyOEr5wDI8l8IiX0NMNxAAkhSABUoHMOM8ZI4JeAz4L5M0Cz9HoAViVImIR
+AIkMT+sBHXA0eEDkORglDpdMLo+8BccNOOHyLHWuEy5SJmENkpQnLUG3yYhwali6/1EADkgaR6wz
+AhEcWmQCh25fsk0CbF5EDYgtIJ8E2kH8cqj/AIuANcyRkrwE661MgiGAXDnSLSAKQptAfsSDjB0T
+C1oZIUBoH+ZP89dgvTwsQiwSUY5heIBEQcITpDUMIgA+KpASstwAJKwfRhYpyAKwJRJYgItLpiDh
+LyEoqMfmWe1dXA60HiqJpIhjYIXg0hY0AJSTytACVCclfIFBToAxGhyL/BbJQyKOJAyq4GF0pAwW
+i0TKJNxroq0xOH9YBmyOlQnSJADEIVvN454ILgIGN7Zk3OogOISpwjoAEcNXZDKTwKrYApEWwB4l
+OpUAmiG8gUMhxNJxgzAjAAvI25H18BiVgntiAkaOUIQBHUIfCiDUkWmTDTCGiCcoEjBGBImc9A9b
+go7leUr4IqxmrUyEDtCO5QnxcHkADqRIiVoGjsnlgcwLRBwBj2OBnLg89BmkFG0fWBzCxA0TnixA
+oE2RisS8gIo8T8pEIS9oYS4kuoYslDythgIZ2hU4pLE8AoDO8hxlA0TQchJQNymAZSXmJQIRes+y
+OnvSwl4KGDCDnIGhIS6clNdrwXgYwp449DOC/kNZViGP+5GAAAExxiGaZCxBRwvSL6wdSQaKK5P3
+wMgo0HgcgaUQUWAgvmBVEN5IVQEJZRMK4jxLwmVQzJO9R3wXGAlMpQREhDRHlx0UiDLSO0t4PsMT
+JoBNQXcEIleAtnmtKU4gMkobB/pGcbcNuwuypkDinTixgOJBJNVkRigQVabAwEoRGOgDdgHdSqIk
+UwmIT8pks46E86D0BO4haK2LHIpWWFCcqHlokftJPJGoZMnTMiBFmdQT8ohYKEE5AdjABShENZVL
+IIKeEzWAnCDQYChYezpADkkNtQZW5PXG7QrcX+/NX9stnO1W+IMeYGAUIOwk0OlYWGjEdgPeC2Jm
+vrabBiaNQKB9/s+YboXJHMAz7yH9tcn+2mR/bbK/Ntlfm+yvTfbXJvtrk/21yf7X22R/99P+2mSh
+bLI/uKP+/5ZNFhj/HLydFipIPD9ZoPWIWHz6Fp0s88gwyRYd6towKaIsM3kyOzxOBYMWjUTqABNH
+HQjz9gQwolyyAYEPE2kAKjloghxu+8NXYi8ZZUeWMlBtQJLyWhkYJhJhu6C5o96DKgdXICVyHlSJ
+mwiWsTpvZmgeoVZE+BvNrEMdR0QJiqYTiGCaRgfCndhXIC3ZvKXEaJ5m+MlEsYKOMQWMdjSGBCVQ
+kyOdANUvz4tm98cHfh+p/WWofxlqMEMFXfcPZtWhRSblRZmHrxJhqOiBAdNyzml1FA6wVNCc0cXz
+R1gqKOuzublOnW6uMf7FIespkGUMWhWyL0YmIZxGEeVUnOZiEEh6k14F2YHMaWwKNPWCxiHQTeVs
++i+D+MsgQjKIP6hx4XqVGRaNFJYXKYMAfSDPzDmESYMjAIMQCYA/xCAm07mmYBDoB5MlTWcAfenL
+LEMFhBdFqmxgSgR6umXGyLrTy4iCI1OlZ6y9v5tjf9lCOLbA/sHARlZAjxVH9QaesgUQ74W5swUK
+B/UGngD4M2yBnSyy0cEW2D9kLLGCcfyHKErUVoIijI8kZYJIXN5QxsvobSROWgygRveYnOdJCS/i
+dhX6vTiyiaKVNIkbGbokWGtBN9EniK0z+YKtRHMANiNGGXFaEW8z0VhEkZQw2CssKeAeHzqnwEAn
+PnYsQ08YKdNYHpTJjESdXSI6fkkJx2luLXSNsZqnmRQUWOLKJk67AkvKyOYQlhA/PCnB7RAs4cjG
+VAEwLVCnO099iughw20RRB0rs5qDDPcGzAIW89QEMl69rCBlC/Q1mLw8OZgG0Cqgrw7sSUHAQ1P0
+kia1dVmymamVoZs7T3Y99JbMEhOepYx47dCJXmDIYNGzWyhAiQw0w4lkbCzd/0KLkw==
+	]]>
+	<![CDATA[
+	EylyJVGkFmeBQxMXa3NYWy+xTqZZpk05aVwssCZZkNNvCjJvJR7q2RcEay1Jc/4SMoySA21kWSNf
+3P4o00Nu8rKFpNHPD9gRcaNPRrsb94VlnF02TwbMcJJsLbGgSS8r4KZSgSJKKEj0NBsuLwmWadFL
+moQIiJlu1mJluh9itGSWWMnAKNN6xbNa/gHtOSdFx1Zs+a8O/1dYhxPWf/LoHNwYEAUZ1EiW04S1
+IPPc3M/OIXDENAAh7f8hWf2nz86RJ3WX0mPTVv+c1xSUIIYEMuC+mgAiFJOluCzP82SHn+yG4gY/
+3VuHEuSnNyRcgOx7crjlihKAY7RYCqiTxyCA+wjPAZ2IeDwL1OJoMAhuLOMWFN0BRKlCoMn0EDMW
+27whvWJF1B+wMWDt0fF+og8DvR8ktIQEQPBsQXOakG16FvuqWTqoO8g0oobGt4DJw7G40Y0xNtDr
+G2IOYdgJlhTI3joUFHBopHEBYN+7AESbCZU07CCNZRAxfKWg4VES8Cw2TtK0Jx4sLSlPxyoXMFcd
+N4QFMlKUaQUSosNzZLONvIZj5hEzGPKBlfIk0AkkBghAupFa4OkmPJTRCBG9DEsYiaGdEgqoTEAJ
+m5fpjLAyQ9/DhyJtnWNRHYLB0d1pvRZR8v5ve+e2GjcMhOEn8Dvszd6UhIwkS7boVbskUFhooe0D
+GGK2C8FbdkMPb9/5/5G1OdCS0OxdLj0rS5aswy/Nt2MQDkwTUyiii4svbRmyAOqCTmGVjT0EEgLe
+wekKlzBPoFYWBE+rSJyjA57AAyuDE7TBUjBtqHKseLThQV7ZYVjbFpAit3feDzgSAcalWQdoHzi9
+6YE2NCEFvGnNvO+ARwFCCHSraztnqE3RruKhOIJTPRQINwk4MAIrfQl4Jypq27k3U0UJPJ2QsNrR
+e8NoBJuKRJe0h9cVpamELjwOXp2myJHuYVVY0XgfHNARyIGtIC5UTbmkg28BxcUM+aTvJ1LICrzR
+aCd4qDtDpGBj/w+VhoKJIxoqNbHGvgwSD7nHa8oTMxSoA309FhvGrI2kjnGSILzEJLS3G4OlpsXl
+8gA5lZ5ipw8YW7GEURSDTjiShBoy29EEKuylo0Ey/e8weBOjQNrQ5GiVHOfDjSycsMAB8MWo0BTE
+cvRi0RXRgW23AUsU2zUkYwNh6+FiZ9DGWPgB3Qz1RG50L9of09hAI2hHOqHD6QsGWpvMIgGREDEY
+HQ5hXYF3jARywZkt9kT9sNWya8HwBOPiSNxwqOic0iaAKsiETYJZpvWWRdaOT0sBI8SiXth9XUB/
+xgSMCaSF3AdQRkAJ9N/D6Qpy8s1f1rBXRfmqKO8pSn/CU2GPkKMqE3TRd7EzRQmmTuRlFWUpx59p
+KSzgNJLS/8ep8FMkpfPPi1hoABPJW10LQnLgp6sN3BX2pGCXVay0RIhzxL/ksY72hJGLpayt92wg
+MzEDghysdyL+bgIDOud+tMzPsGoe29ZHG9YI3UFrpnPu4Oacw+nM/AzVcue5qm3d1BpVW611zf1x
+2xyj/uV/v5Mnde1qYag4+8t20gXoZTv2qSPRaeM9q8dd4Gsg+BKIPqksLq724/h1ut5pel7p7PNh
+uh5/2fVnnUV/z9c6x+O+d9PtdrjZDgdU46x52zwsYf3evihyOV3zeyLn581y+WnYjF/2w/Zm3Deb
+w/BjXAzTtLvVJvquvyw2+/GgZY2Lw7fdT1j0ljn5cnn58ar5A2nW3yo=
+	]]>
+</i:pgf>
+</svg>

--- a/misc/openbadge_badges/badge-instructor.svg
+++ b/misc/openbadge_badges/badge-instructor.svg
@@ -1,0 +1,649 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1"
+	 id="svg3004" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi:docname="creator.svg" inkscape:version="0.48.1 r9760"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="108px" height="108px"
+	 viewBox="0 0 108 108" enable-background="new 0 0 108 108" xml:space="preserve">
+<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:pgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:pgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g id="g3014_1_" transform="translate(0,376.07634)">
+			<g id="g3016_1_">
+				<defs>
+					<rect id="SVGID_1_" x="8.996" y="12.472" width="94.089" height="88.952"/>
+				</defs>
+				<clipPath id="SVGID_2_">
+					<use xlink:href="#SVGID_1_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3022_1_" clip-path="url(#SVGID_2_)">
+					<g id="g3038_1_">
+						<g id="g3040_1_" opacity="0.75">
+							<defs>
+								<path id="SVGID_3_" opacity="0.75" d="M97.635,57.893c0,24.043-19.487,43.531-43.529,43.531
+									c-24.041,0-43.53-19.488-43.53-43.531c0-24.04,19.489-43.529,43.53-43.529C78.147,14.364,97.635,33.853,97.635,57.893"/>
+							</defs>
+							<clipPath id="SVGID_4_">
+								<use xlink:href="#SVGID_3_"  overflow="visible"/>
+							</clipPath>
+							<g id="g3042_1_" clip-path="url(#SVGID_4_)">
+								<g id="g3044_1_">
+									<g id="g3048_1_">
+									</g>
+									<g id="g3046_1_">
+										<g id="g3050_1_">
+											<defs>
+												<rect id="SVGID_5_" x="8.996" y="12.472" width="94.089" height="60.786"/>
+											</defs>
+											<clipPath id="SVGID_6_">
+												<use xlink:href="#SVGID_5_"  overflow="visible"/>
+											</clipPath>
+											<g id="g3052_1_" opacity="0.64" clip-path="url(#SVGID_6_)">
+												<g id="g3054_1_" transform="translate(147.3794,85.8701)">
+													<path id="path3056_1_" inkscape:connector-curvature="0" fill="#FEC341" d="M-89.623-14.21l45.328-10.739
+														l-4.811-11.497l-29.209,11.827l31.233-28.749l-11.184-7.164l-28.445,35.326l15.784-46.417l-13.273-0.455l-8.127,44.384
+														l-8.562-45.706l-12.344,5.011l14.763,41.621l-27.216-34.201l-7.569,10.913l30.339,27.546l-34.05-15.046l-1.419,13.205
+														l40.594,9.439l1.426,2.298l3.771-0.895l1.432,0.715L-89.623-14.21z"/>
+												</g>
+											</g>
+										</g>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="g3058_1_" transform="translate(57.3389,463.82834)">
+			<path id="path3060_1_" inkscape:connector-curvature="0" fill="#F7941E" d="M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248
+				H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3062_1_" transform="translate(57.3389,463.82834)">
+			
+				<path id="path3064_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3066_1_" transform="translate(72.5313,439.77264)">
+			<path id="path3068_1_" inkscape:connector-curvature="0" fill="#FEC341" d="M-61.955-354.134h87.259l-2.13,6.917h-82.202
+				L-61.955-354.134z"/>
+		</g>
+		<g id="g3070_1_" transform="translate(72.5313,439.77264)">
+			
+				<path id="path3072_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-61.955-354.134h87.259l-2.13,6.917h-82.202L-61.955-354.134z"/>
+		</g>
+		<g id="g3076_1_">
+			<g id="g3082_1_" transform="translate(63.3096,106.6533)">
+				<path id="path3084_1_" inkscape:connector-curvature="0" fill="#FEC341" d="M-58.546-48.095
+					c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799c0-24.262,19.668-43.928,43.928-43.928
+					c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669c0.656-2.941,1.054-5.981,1.158-9.095
+					l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66l0.715-1.86l3.229,1.242
+					c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665c-0.748-1.979-1.618-3.899-2.604-5.749
+					l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209l-4.565,0.718l-0.311-1.969l3.411-0.534
+					c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119c-1.622-1.334-3.334-2.561-5.12-3.682
+					l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908l-1.251-1.55l2.694-2.175
+					c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952
+					l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314l-1.859-0.719l1.248-3.227
+					c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626
+					l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566l-1.969,0.306l-0.529-3.41
+					c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053
+					l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609l-1.553,1.247l-2.17-2.699
+					c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394
+					l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+			<g id="g3086_1_" transform="translate(63.3096,106.6533)">
+				
+					<path id="path3088_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-58.546-48.095c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799
+					c0-24.262,19.668-43.928,43.928-43.928c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669
+					c0.656-2.941,1.054-5.981,1.158-9.095l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66
+					l0.715-1.86l3.229,1.242c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665
+					c-0.748-1.979-1.618-3.899-2.604-5.749l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209
+					l-4.565,0.718l-0.311-1.969l3.411-0.534c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119
+					c-1.622-1.334-3.334-2.561-5.12-3.682l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908
+					l-1.251-1.55l2.694-2.175c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604
+					c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314
+					l-1.859-0.719l1.248-3.227c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398
+					c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566
+					l-1.969,0.306l-0.529-3.41c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27
+					c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609
+					l-1.553,1.247l-2.17-2.699c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277
+					c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+		</g>
+		<g id="g3096_1_">
+			<g id="g3102_1_" transform="translate(133.7676,136.4482)">
+				<path id="path3104_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-84.59-96.67h9.725v0.986
+					c0,0-0.304,1.084-1.52,0.761l-0.76,0.169v18.668l-2.584,2.41l-3.038-2.189v-19.059c0,0-1.519-0.105-1.824-0.433
+					C-84.894-95.685-84.59-96.67-84.59-96.67"/>
+			</g>
+			<g id="g3106_1_" transform="translate(136.9014,135.9277)">
+				<path id="path3108_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-85.749-95.822h6.686c0,0,0.911,0.548,0,0.602
+					C-79.975-95.165-85.749-95.822-85.749-95.822"/>
+			</g>
+			<g id="g3110_1_" transform="translate(143.8926,133.6768)">
+				<path id="path3112_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-88.333-92.151v18.619l-0.861,0.327v-18.668
+					L-88.333-92.151z"/>
+			</g>
+			<g id="g3114_1_" transform="translate(156.355,123.4932)">
+				<path id="path3116_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-92.94-75.549l-0.01,0.01
+					c-0.512-0.498-1.208-0.805-1.977-0.805c-1.568,0-2.841,1.272-2.841,2.839c0,0.771,0.308,1.466,0.804,1.979l-0.004,0.004
+					c0.019,0.016,0.035,0.03,0.055,0.047c0.096,0.093,0.198,0.177,0.306,0.257c1.804,1.601,2.943,3.932,2.943,6.533
+					c0,4.829-3.916,8.744-8.745,8.744s-8.744-3.915-8.744-8.744c0-2.559,1.105-4.857,2.859-6.455
+					c0.763-0.509,1.267-1.376,1.267-2.366c0-1.567-1.271-2.839-2.84-2.839c-0.775,0-1.478,0.311-1.99,0.815l-0.02-0.021
+					c-3.029,2.645-4.948,6.529-4.948,10.865c0,7.963,6.455,14.415,14.415,14.415c7.961,0,14.417-6.452,14.417-14.415
+					C-87.992-69.02-89.911-72.906-92.94-75.549"/>
+			</g>
+		</g>
+		<g id="g3118_1_" transform="translate(0,376.07634)">
+			<g>
+				<defs>
+					<path id="SVGID_7_" d="M10.102-318.612c0,24.345,19.736,44.081,44.082,44.081l0,0c24.346,0,44.083-19.736,44.083-44.081l0,0
+						c0-24.347-19.736-44.083-44.083-44.083l0,0C29.838-362.695,10.102-342.96,10.102-318.612"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3120_1_" clip-path="url(#SVGID_8_)">
+					<g id="g3126_1_" transform="translate(201.0342,157.2715)">
+						<path id="path3128_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-109.454-506.695c0,0-0.747-0.257-1.357-0.654
+							c-1.307-0.851-21.334-0.217-21.334-0.217l0.667-0.552c0,0,20.472-0.285,21.284,0.129
+							C-109.384-507.577-109.454-506.695-109.454-506.695 M-143.388-500.48l-0.02,3.125c0,0-0.077-2.039-0.916-2.181
+							c-0.838-0.139-0.358-0.953-0.358-0.953L-143.388-500.48z M-109.159-508.086c-0.732-0.806-4.407-0.744-5.435-0.761
+							c-5.566-0.082-12.748,0.203-17.945,0.163c-0.21,0-0.935,0.348-0.815,0.645c-3.694-0.022-1.77,0-6.23-0.066
+							c-2.414-0.037-6.245,0.872-6.355-3.396c-0.061-2.127,1.896-4.011,4.221-6.279c-1.47-0.462-2.962,0.525-4.452,1.344
+							c-0.731,0.709-1.227,1.19-1.838,1.785c-2.278,3.288-3.179,6.6-2.667,9.929c2.038-0.378,3.535,2.415,2.094,3.72l-1.271,0.012
+							c-0.602,0.004-1.083,0.619-1.076,1.366l0.022,2.96c0.006,0.748,0.5,1.253,1.102,1.25l6.417,0.038
+							c0.603-0.003,1.083-0.618,1.074-1.369l-0.021-2.955c-0.005-0.751-0.502-1.356-1.099-1.352l-0.802,0.007
+							c-1.395-3.988,1.211-2.796,3.79-2.755c4.848,0.074,2.567,0.045,6.838,0.074c0.243,0.297,0.121,0.839,0.791,1.124
+							c0.415,0.172,22.823,0.246,23.283,0.14c0.462-0.108,0.343-0.331,0.512-0.497C-108.8-503.849-108.279-507.122-109.159-508.086"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		
+			<text transform="matrix(1 0 0 1 6.8179 81.4541)" fill="#FFFFFF" font-family="'Arial-BoldMT'" font-size="11.7746" letter-spacing="2">INSTRUCTOR</text>
+	</g>
+</switch>
+<i:pgf  id="adobe_illustrator_pgf">
+	<![CDATA[
+	eJzsved6IrvSKPzdAPcAtrHBpI7Q7Ux0jjiHsTG0bcYYcAOz1rw/zrWfKqkznQjz7f2eZ/bag0Gt
+VkmlUiVVSfHYWT1TbPVelQyfZaKReLysKo1hT12LktLofqczGgxVLEpcJKOsmGWgUnFfetYqXivq
+oN3rrpFHWQ4e1vDtxJmqDIa9bnSv1/lSBsloIgmPLtvDjgIPXxutdyXT7kLLoyY0kh38ek/qwKG1
+SmMI1aQcC//no/k1To6eHePzRvdXYzBo/w88ZfO8xENZqTfqttrd91Lv37UoJ7JRXpCifJ6JCgI+
+3mtfKANnnaycx0qClJVFfEOUs4KQ5+EVLssXJBneq/Saoy+lOzxTe01lMCj3Oj11sBYt/250o8eN
+d3jSiN4pnU7vn2ip02h+Wl6p9bpDqFpU241OptTrtI4vLU9PFKWltFzrFPfF51q7owAGvxrDKMsi
+sov7LPdcGrU7rZPR16sCuOVlGYv5Z9KpqwH0BjqG37G48Lz/BSV1ZTiEEQMMnLCL3ZJ1IFBI/ks8
+XCjvbTK/gPWnpNas2ut/NdTPAcWVCIji8BOwJEYFkcmKtN6l8tXvwEwRrPKMiHXkPH6a37WaMChS
+iy1gE9BCVJR5+CwUBL2OiXDlV1v5Zy160usqFCdFdVincy4IDEM/6ZOLUUdRr7rtIR1ncV+mSDnu
+tZQO1Dfer3UaBBfkP9b8pBUuG+q7MgRC6XVGQ0LNkg4BkH7U+K3g3LMUwGlf6V72rkkfBQEGwkU5
+mKsCF82z8DVPGs/nYayCAY81P2mz2Ag2obddgEk6g2k7Vdvv7e6a1rPC867abplTCTAk+kE6n5Us
+/2T9H+0lDHg4VLpar4GEyscWkmCyx3WAWO22yr0vxPoAVxLQQhfIpNN7p8+M7+QJvD7qRx4ivJz7
+HvWGygDa6ihROZ97Vxu/lCjLSbliq63Awm8PckDZ3fdcuam02p1OI1dtNEdDJXcyBDpWcqd6tUju
+ynijQas0SGu5RrOtAkG8dZR/cw2zDn2/QRpv6o0r5M1ITqGvKpZXFePVNm2+Teu0LXXaRp0uaT6S
+69G6PVq3Z6nbM+r2aFdGtOqIVh2ZVSO5kVG31Xh/V9RcCzqoKLkm4Ds3GCpqB0cxUJpIcrnXUaej
+DHP9hooY6H/k4I2vRrf12gEsqWSZQmutXLPX/w1E8jHMwbJtKbhQc7QPBrhstzdsKW+5YjV3Oug0
+Bh8Ro6gP7Pyr3R2ZlfS/v5Vu7mvkLI6M1dP/9tTWmwJNtbsKfv9qDJqjDv7QKzSgXIP+PQJhAINs
+9f7p5pR/m53GF/kK1NVuNjrwgvHWG6zedne8G+/AATvKVw8EyNvQ/EUxAXy43ceRD/qNppIr0sko
+asSm/anmekgj3RZ0Kad8kT+EkAHFpFH9B22T/DLLaWGr/auNBGIgzcD5nfHtTW3QGa2O1B7pKVkp
+Rr/JL9JcJPfWhgFr5AGQc32A02shgZC5NtfZa2OgGB0kP6Dq8KM3GgCJRHJFC4lWLd+LlDKqRueq
+FDX7tHzfSq77RqV9WumUVjq1tKeP+5TWuKI1rqzNXNFHLZwpENU5y9t0Ir4aTRXpHfg8qdZokgVB
+lzRd0ZHcx6j73lBHX53GaAjrEETBZ67ZgPcil1XCQcWD58sBCAxTTvDPhE1Vu80eyvq16LNVutpF
+7UPO9jBnq0mZ9uU9bRT4oN5k9FIdKZe/+0rkgc2z2nIGPs/nAC3K96jRgR/5XLv7Bsti+Nuy2BAV
+pALwSlBxAM/4I8JKLK45WPNDgN9qv73lYExfRBrn+mqvBdpRrt+GFofI26B5Sc6dfinvjWiElcUc
+MABcP1FWLuQafXjhX60XspSrKB1QUThW0IgWFtv/KN13JcoJDFbuABk/139/vfY6zzn61zZykaLz
+GdB7BnODkiNy0o8Q3e+sM4JHu2pv1N/vvvUiCaosXgLlI5pOX38CUwOdTyswv9VH7aGSbbT7Sd+G
+QHipSpQ+hJfJT/1v8NsV5Q0UKPN1Wlrt/lI6vb6lWaMEllD0pqH2g5s+6zS6DTVKyo2Wj9og/c4a
+gCOzbbMsRKOgAfRRCvzSO+cA4FPB8igEoMbwA7RVYIEDo236095xWhbcXr2JOoYaLamjwUf0stfr
+GM3aHxmta8WkFOv/d8A4Iy90T7sUQeOQtApOSKBX/tdBgdreEODhf3Pr5QbIcaL8tJtuAFyeG5Do
+s0kIi7C89uDLpCdLyRmy5GZHqf8GtevLrzXEBvD7FhAi4W5mb3tffbQ7o/WPRl8hbQ4/aqRm3WhQ
+RPli5bGZjD/znfgFmT5BG2r4G+RQJHfYBd2L/IiuATa6PcBf7qTxpUTTkVy9DUadoj9loqcRxmLF
+sNHbRkQ3oJjo7W/4cQBffkLRP1GWiR5HH56YaAuKby9IxVvQTihvXI9EQSi9wV9HDx6gtDHqDJ8m
+7QZAyBZEhoPuZPMFOS/x5AvDcRwaQgyb1y2w22L4XrMevSa4BOSbmAycjrMGqPRgmSDUs9fQvXWa
+5WTUt/8TGTPXz5qRs5LRDR3aJORwBM1ZZ2BslKTCNHTHMvQRXVXYzP+nFUNDjkKPxrW+6p6BSmPY
+iMSfc/pvIAz81SbadkP9TX6LnMBJ0dw+PE5AC1FYx6+9htqKNtEvAJb6a2cEizEdpiqo4CFroiLY
+pXWZaK4EDIhW7MPKV6OD9teoQ+aMVuEsTcFkdsFqUZVu8zc0025F0b1F67GeIOnzvCjyone3WGu3
+kKpzF0qjc9YDFEOBTXdAN8MzCM6OMjYIlo22dIS3Bz10+AAOFeJPC9kNE+WBVQ2UsyJD+0srHivA
+7C8aaAO3/4egMmq6a+gbTkowxgCm6Setwuf1NvuNlgZI0LoDPdDQWtDnp9VvZx34aIB8MCaHFg36
+vSEtWse+RoujYc/oqjbu3O3x0UmvpbiSLLz27xcYwS0lAxqA2n4Fm0oDAoaJ2qC1/nQTc2jfUqv5
+AbaeqjgIXn+KH8PffQ05ieXu4PlXQx2sgwCoD9EQtFf91TAIiJQPPOp1QXgYM6FVTP+vxw7IZyUE
+Yjq95icunmDM6DXnRJjTjuu1TXgIG2JsQBx1ZXhCBhE8PmvtOU3/jJhgfTERavztBjDdMIQfOKv/
+mxb62q/QSx2r/ocpGofXHA2Gva//LCf7c3S4NmigXo6aGCyxsOT4x9cF9OW/qCv/L6zSwds//8XS
++D+8DAaddvN/Oy/mxXyW43lBV4i9xvo7zOz+/k+zXk4UsrIsBQ3m31Ck+p8eDMswWYFl2aDR/NNu
+DT/CjEir+J8dlVTIcgWJDxrUh4I7Y2FGpdf8D0+WbgZ6Dei1NwSF4Eh5G9K9/TBDG3/nv0D4E65X
+743UpkLiaf7j0h9k1H+6C1/KsNECZWjWfsgz9mNRd9GEoS5LZfIyCfJh8H80uod8tTRUv94lMUGl
+3r+3d4Y/hPQXi4uq0igSL5K20FkZg4YKsoB/AnxOSOO4qaZc9vqklr19z+rX7UH7td1pD3/Xh42h
+6bWizMX5Wq3T66mnb28DRWtf9KxKFl2/0YSWtaqSZ90LZEDVf4dKULcxQkkTu4zNrXU6GvZHwwDH
+locz7rMLdnwP3n6ne4FYtVBgEenaFITA/XWj2x58wDRbkK+9LQkTTWCJ8CxLMzxXyBc8EEIwt2t6
+JxMsI2UZH8LbszB7xnAgAjoMZzAJT4oeNbrvo8a7Ej3r9XWkkEhB4x39BRpLWDdddBbd0yFAcBuL
+uinRWQGT2YQlpXfS9DMYomB/oL+g+dXNOnrfK+1Bv9P4fdxQP3Wk8wUyc+SPA+kkzM0qCmhcHlmt
+lroXSueyd0Hr0cnqDdo4EPKU1RU/2QjpC/sqZwxQWwjFCwdb0wdMkBhyTm9MtcRr4ZCF67vg3cnL
+xNd+t6X8W2urg4Al6nylrjR7Xd1FLEoFwa+HFkr2YRe4VKzcgvesWVY6HZMyWdGvXhlk8VCnCs8W
+93rAXnpd6zLiPEZ0aVqCD8dKqz36snCkp/EF4LYMtehDRY1iHLAyjJorwLoF4MoWLnTfpOdUYa2S
+IfxYG3sk8NRfSvRS+XcYrbbawwYlm3FeykTfjG4CH8XgtegQ3hpv1lqzrwPo/VLUPu5XOTcEHC80
+O+1+tNlDv8m/UQzk6+mWcFBnBkO196mreAlGW0xRxn1VYTipRUQnaEC2pdJncb826nT0qdIit+Gp
+YXaYjNXaHZVIp8wvBUO1o68NWI5NnWk67VmbHlpXOnuNIcDbx3i2/crAwh08ah71mo0OEou1rrXC
+JTpZEGqwkCFL06CmwJomRRVkwl4lns1PIABxMVqXt5QvhJfFhKZnFsbIGnWerbEub3aE9AKwQBIN
+zQmdCBzptLvwn0gJNNuxa4HIKnwUQWNqRUmWWJ+K5swKnqwU69UaTaWIQc1BlUmHHbV9uZW3CJME
+PjytmW05iY2JZkRdtfR5X8Ft6F8KoXc3avMWIAS0TTHm8hzrJRURm1ahGKCZW5tdx6rNntpSWuMs
+Jpo76Q1tjz1klEU4cdHivp9AsqnkIEGqZ/XoEbJfjGfC0EAiSfyUcgLhVGPal64ShDZbRlFQ1kTB
+hVUUsFadFqueOqWLdT+cQtzF8E+UudhJukHu6GQwcigwH+zY4dLqwYAL5iY/7Su1cHLXVIaUrDKE
+dVQdG/kYGnVU163yMYBOdCg503WS+9l7zQ4+2/1X6M2n09R2VuyDVaGCdaHrRuOKkPMNPbjB8pZX
+L8h4G52O/srAzlOc1TF0Wh0oODrVv2az1+kYvCYIuiFtNU0K458Oeq8Y5xY1RS7jOR/upE8m1Zfy
+3ReSbXZZa1RNt2cqX9F2lyhXaK64KSXjlOCGqmZHBVR1odEhhnMMQs+x6VhhTTZia1ltZQcYWJP9
+5T0Jza/sFwDRoF5l69nojfIK+IKpa0UfE/Wb07PHZPQX598haKav9t7aTpE0VodqsL3hh04+ASPt
+v399ZunOptm620D+7WdR3fUGT1oaYGBZQB2li4peKyRuP3xaG2S7ynvD9E9x7ljBGHvTd+HeUAfW
+nbZKCpwrdqFHYGlhdqBNVLgSnEHDr5hA6FOXDLPfaf4OwBmyqDYsVv+m3mCCPnrq/wQ01gQjPaAK
+TJAxQy513rrDbKtjIewQRAZraohJov6YM9vMu9EFaYlkMPbe3rJDyzhcaKjfV7MfLt6lsQZVS+yl
+T4MmZhC4amvYnYSRDjqNvh8RU1T21beeIRa9OD5l5oPX9vCr4TOBRlU7vwgaD2YxBREOhvK9NtRB
+0LDVd50n+tbxX9uvbeTz/hxJY+xEnoQmm6CZs+OF7tj4cnid7Ta/fvstdqRHEhQaSLQ9i0Obd+eQ
+gKDBR6OFeV2h1iAoK4Nso9vVIxpD4Mk6cp5xGxJMgaqOq8+uDJZFWd7QdyZC+Z8coLpjvlZHhV6/
+NQo9Ohu9BxHB0I9jEsjNnj4yS8y7n0QH9Y3mh467kJ3zrAzRZdNVBgNvMhwMO9kWhQ==
+	]]>
+	<![CDATA[
+	3O+3fNoD+qLyPhTZYLO0utGqG3RsVYMeRNz/WImbyXKiJ/ahQVQXLXvcbgLeYHev2talzzRp/MLi
+ChQ9ar47yVr0kLl9zZvuz49byqD93rUIGEwodxs3IsgcLyt5VWrjSQAWGi7Inu0FiUCUQIPR6yB4
+5sJ3LEAyW0TjLz/rjDAtK7V6Lr+B/xKCiR+SYFvfOl/IyAe+k0l6ZNNgE7DegUpb0dff0YoKuqga
+oAwBkkxOVnCjKxiRzRfrRVVUE3BSquv6tHGz0UCp9Jol/BlOeCAXgPWPylnH7HuYl3BhKmrXupPm
+y7pofX81d9juGBkKrhKZaNXN7sA0WV3l5xhTHa9Fplv3lw98mAutOOo29Wn1XI50gVhlqygL/pUt
+CovdhC/qtS1GvM4j69e71a9XpUX9M+MGvmju7Jy1/1U6Z4r6pjSHdrRCI3ieSR3YAz1iwmGzj7mp
+u7pmavUTUV+Cj6PI7qgjvoJQfjq9j5XLiqNjUIjZGodAe46hw5NbvZNWXGmZ4OPtnL2/jQFEpJi7
+abz54ExVmu3BuC8RHuEgaIql2zN64Ap9IpjtkUytS2tMkrULuKfi4rgcm5WP3j977ZYyDpfkM5JN
+GTxeYYxI6o1fyjEsy3a/oxTtDqxA563lfKHofFUiJJGzSu35Um30+35mql6xgmdUdLUNlE5bt7YD
++Jf+tpaZ9/skLOPTX6QhIOVet2XREKZ7d78F67T91g7p1bG3gnt05LgjtAcnHoUFeZZ3Lz/A5Ili
+Lv/wQ4lq3DuqMYlB9J8PpRsdNH5hq42u9aypKHYi2hhgsZYcXakZoS/Z6NWANAmf9sZ+90ZRWCLd
+aK8bVRAp0DKCps29N9pd9BdaAKWjAMx4tQuyLjrsYRNNJdomzsVGtNP4jWE2eGZCm66k6GDU/MDu
+7XcrRGczm6HQusCkQH5Ge28m+PYgOup+YuZrNjROm2q77y+z9craxO13mzA2Bwn7vecx+WFfJ6ct
+lYnCPAnU+hAYNrAJ35osHRe1motNtffaGNLzknxXfeC2ftiXbNvvripY+I3yEGC94wQsezD290Pl
+RXqgiWBX2/i5tCSh+voTQsesTW66O7qE+5JkL+rEVyvU3zI2jSwOY8/KVFFB0XiBvfdtXSArUdOD
+g/tBqoFWYnp43JBoqXvpawPZql4EeKRslUsW1TG49pFhIrr6RAwsE6O8pva+QM7/01M/rVAme9MY
+92SvTdvRC3/r1uQ2xLLAsDxTnfJyP+gvXartL3zjJsCENoCAtr7v66bXaxLuWmoEMDxW0z+wDyFq
+6t31cROZ8KmxC0i065xulY973V7zA1CulE0b+bCtB9G5+wbHX66AgKRZZk6eIri6YawtmO+SMxCL
+r71fIXiHG2yz35yY93l3V238xtMN62NJ+161Lcg5HzXMyDSO85AwxpveowvqoeuEuHu13AE6pyJo
+kJMjkpB6eExqeoc7KgPhuOLDfwLIez705YtMx8uTYNPxqtldX7EOsvlGecUIrxDzhdoHWJWXH6Ov
+126j3RnY7VUvxgCi0xpZGUaJsyjeVaqdlxt9Gp/ZVvxZF1EbQe0nHPrS4ttZB0u2UqO6QtmwDfVn
+YyaneY6L/VgR7Co9bgQtcP1ZhAzBWoJmbLFe3t+XxIqCugy2mtoSXwqp7evXHJNLHadT2x9DHr9x
+wsb5Gm88ODe+kQfr/PblsFR5k3c/9xYvNhuVN+Zuy3jKpTYv8h+xlf7VaizN1YqReCx9fKPEEksP
+Cfh2uxtL8rtfWf5IjqW2dmPLwoBfOieQhe3Tly1m7+VgG/slpbbyq4sVRS2Nqqnjo5vK4X6srj+t
+fGZzA3FPfrnc3azelJSLSHwnN3jfWHs6O5Yr95Xtj/VtVsqWkl/L9fLTfqdSfXhJNdjVYqErxsrJ
+cw3opKOCsaz0L79j6Y+fe7FUMwtDe2494DDrscTeII0/77ShbfbjUw4tEieDWx+9XwuVRSW9X1Uf
+Vam4l+/VYVTXUmWxNapWtlcPxfX7w+PORjz3XYahrfUsQytnVi+EAXeU95pEDmYfh4S9XRqvdDRQ
+1fXBpfp4n95nckI9YR3Gs1IeSLXhNfej97nMtJZZgtRTE0/qEzPYgJalEdIYmWRucKzPm7QrSN/r
+P+HnbgfevqvYgT6qT8eP5+5Adws/xLX9H1kHUG0s6o+lkyMC1g1ovn24G3cHuhFLqAM2rroDPWMf
+hQVubTUSdxvrYCV9nPEAKn4kGit3VXegwt0tU2NWjx1AAQoBu1Br5ZcKF8kTN6BM7fKm4gE0vxg/
+qxeLXkBfmN3F+yuA4jbWhd3Mzsr+a/bWdVYffzbyGtCzlRUHevn1YadFgAItvlYJUISizeqd+sQd
+nCDQ5PisZh+EzeNyCoAKvTFS+rFR8wQqdk4XhpG4A6wBtKH+WI5fewCtNfPdlTzvCnRQfOIdQAkU
+CnZP6D3c9dyBbiwkBiuFZdUNqDp6YePJxPbDkxtQpiZXYfY9xppfXKpfq+vuQIW7J6b2tHfhOtKF
+2mA9/pm7rptAI3EL2N306MQT6IryvnPqMdJYTh30z5YQ6OoYes9rsF62CzuxYwBb6DvHelQo3WlA
+7zIJB9B8/ejzmgKtPn7WbCO932GOHqqiCRTGYhnr3veg8Ll4nncFeryqtj2B7nw+l4seQB+SQMn1
+NWXgOtaFw8zjYUtJD12B1p+31z2BnjzuHZRMoEBjNrBl5nrlVnIHerQ4qr+/tiRXoNdHbM8TaCR+
+tZvb7XiN9ZC57vM7HkC3k9c/bl6KrkBvtl9XTaAwL3awz8/F4Y0H0EeBeTq9TLoDPTl9/3lb2Vh1
+Awrz8jTMnnuO9esstXzrBbTGPJ9/b7gDPd1Jqg/FQZkAjcSdY63+zOQ9gEp7sZsT5ogCbSwMd+2L
+Zlsd3TwICDTlABqJD6TTxfXkj9HXM4DdVJ1AX1YvljSgn/KqQ9IsM8cnIgHKrWwl9uxAs+rg/WAR
+gWaQxpwM4igbe1zM1wDozmCMFT72ZAp0O1FNO9AbK9ZOVyjQp+HagQk0EgcEJ69S63ubBwg2N84K
+r9hM4Wj5JwCtjZxA1fZ2UgO6dp61j3TvqhRf3iBAI3F+++royDbWxYeB+PpwhkCZMa50Ii8v3A7P
+9wEoN8ad1eJr9yoV5zccTzWJrKolaeXu6ujxwPXtUSO2wew/poYeT1e22MbgbNHtKcxADbTxWLy0
+VMHn49S499rNF2pLLD51kg08/ejrosztaVctnD7tieSpy+zvDYcSu3VfcH97fzm2c3pTPfd4Olw/
+3D9YHDieGjrMIfN0lEqJI/e3D/PPJztboxWPp4dvZ2uF64zrU+nkno0YspRLj3MqZsmYy8z40/zy
+VeOhuuXxdCNxXd642SFPXTB2VFq9WVLbJY+399LP5fzlo/vT42Lt52aSTzqeGhg7ufj4OXiuptzf
+Prn9+cUPcpzH06/vXuZTkdyf3j2dReL5i0bG4+2n1QeDusefPn9f6/zQ5WnjlttcSBdqXhhTbk9q
+w4VTxf3tN+bpY+Xn/oLr0/jNees6ETvZdseYqm4+n/M754kEPs+OrelNrrR/el76wqdjTEgtPn8N
+Yk8rFdeno5c1kGKr8Y3Yi8fzzeTqzs1qw3y61U9u9Mk35Gh9wqS25L2ln4R7gYl3VjZMM9PwPjfl
+vs2GXj1cZ2PpysVNLH39o47G5WUs8ZAc4bczMDE/y7HM4TPoQrefBfra1mbvE3pT3yHwTMi5Y6m7
+gtr45u2ImDvAXN82DKCLufbmaxI0vIUqmDs5O99UF7iVzbOMZuws9awieGuRR/Z/8EWNndeli0+r
+3CdgNaBC8tEb6ELtR8YTKFMr5U8dQIk2TsCCYtzl1589gN798AG6GxO9ge7uqncWuc/bxirtLX7n
+R4860N2OFehG7MkKVKgvWdF7vnNhAdpaXgZ9zASbWu9cnXgAFT+Q2vruQIW7O2+gC7V3xrYqEawV
+wWA7eAAFaxJsh1cvoA0H0EjchmBmzRMo0Ug8gaI+cuWF3jSxkjzHur/smFU2DboGAU++aRNxMmr5
+14vEtZqni0qYFhdON2Mh6qmj58+4yS00SrZ5iKxLF95OJ1Kl3uCEUj98K6P+t08Qo2PWWPG7pxeA
+4+O09rHNUPeNNvuah0hIX1jX09kysMeVh7LWh8ZFibiTtvqJ1qWTMQH4Uu5DqcTxY9EAoNtiGgB9
+LUJ/HirsaulnDSvxtAnT2bS1VY1bPoAzlg0l3+GjO8dufpMqxA+jDdjsMnMgxuPkA4nBZmhoAz81
+RlBJbb3yexYEWvC+e3UGP5fjRL6MVoM7NdCruHcp115cS5MPik+7z9OwXinSj0bBSCcfF1ab3GV8
+2+zhkTk+HMv4CLWPxm3FnEG3+eO3ry+Pg+YvfdyLxLUREovI4fqk41tf9UdWiPkDSqYzuFvvToYs
+b2LYvXYSu+4h8SV3N2Qxbyvft/6UZdIVoWRvyuqxjaWVvRCY98c74WPruZkxryPrdeCGdzovgchy
+sJ67dNfJeqqP5b4VgDF6bD4Sn2A2flTZ6tNg12iCd0fg7uGyppS5rsrq4+nQsz+kI8jb0/jxYHW6
+juGuihb0oW1VWhm366pMeg6NX1o/PAoxtEjcMTjb0B4XfYdGEL1M15BXRxil8Xyl+WDHxZE5quQy
+GZU7sd+l+3Yx4TqgiOts2QZUydro3FiGNjpnlLPssl1Xt0wTgfL4PTti3tYS915SGnR+g2xMOZ3y
+aaycffBszLMpQyI71t0r13Ouu8bCUYgxu646q84P/WnUjEoec5mupumHNles27bcOUrpBXM6bTTm
+mFD80LggcWK70EZj4Zj1pI3cRy+1SboUidt6tvbt0TPumyvdywfug0yXEi5aWMqOMceUfEp9x5TA
+21eqr4wLYD0WKbaLiKl5CCZ3ndGDFlu7dq7KWazXSef3UxqF1Z4M7cJtz5gi6zXmjywcX86/Szj7
+n/KCZ6fM/niqdLYufSx6y8odc9UGC49dh0o3plg8j1Z8dX7bDAapdOHnT42Ywmr2xmABNKpuTUXi
+kzcWZHeMN2VwS5fG7DQ/G8aC9LoJGrNz2hkxZudoE2NM82xphMaVbu8ydsN1D5dKNax2bOrGkfhY
+b4dbAZzDotC6r4L3Pcc0uPAxU8F21xX2nJb4DKvyfY97GpUOJzCUhZ77TA6345H4zNgJYfZFArGz
+e/YV1o3gMZatAerJHmwh/DSNm3iOjkTCdCWICwR2xEW3nAonnsvemBeHbfjKJ11FVOn2WZjMMqRb
+moZu2bcFOK2RLfILa0BRojKcDIDdqWHRYfbRxN2dgH14LBAww5wS3mrxheiUtUsTMABr1M34kvu5
+Px8GgBwmUV2eBemW8W2vnR+7jQ/0sQmRXhkGaQoOmgVNPjIeRIdU+zT4YOc0vq3du76uW4bzdXrZ
+5D/3mTd24c6TGCLxiZDlv8TdkEVase++acgSZ0CWfYFvDskCt8nKbfZgFMLqDvYuHQ==
+	]]>
+	<![CDATA[
+	OBa4p4fEz5cAevKSf28c+rsRozhOaPzSGjoKgoziEC7ZA8SYXYOfamgJ/6FFQjg4DsbE8qTuDbL2
+vw4YZfB5M+OADkaePrqIleP5+n34JflbCEGBbmixyBdEzLM6iQ/Ey18DuLH7a7wo2cIKbJ4GuyqN
+ocmMXZU+dKrShockSJkem4O188WJcGfRYE+t/fHek3LXhD1w1z8kYpDKSj/nZrAmDEObw3o5dMrA
+iekcMbZ2HrOLv9DeaAudb1/Fec8BReL+lG6jnTtvH7s/AzBprH/olHdTMABAi5uzkEQOe4k6D10W
+sVOYSA6hJa5rs+OiLplI2eM3YFS3dbd157/qvLwKwISn3J+wjEppPGccu6JB8s5T2mFjuXDrJdjf
+io0xs/PkMmB0ZzSjL57M2pjIc93jC27HbkgG9sZtT5y0M/UKtLWi2ZKGPjZtO6HkHkaqBEg+0ph9
+h3AiISqkL2zRtrjN6zQpsWzmHQaDw2BjNrtranFD+mrf9Amzx+eJysuQqNR8FxcO+9yFo626cLSr
+sBwtEhihAWtjZo4GGAO1MoANhedog0/XTR/itZ5wBwkb42bXlDBXq74w69q/MjnaTGv/KixH02nM
+p53ZOdrVfPZeSW+ePbfOdpDGhlc5jYrGPVvjE7bOeFrQ5tahQ0ex+i40Aad1ZQUM4K1VR1CXf+DD
+RDFXt9dOT9kUW/IwnSaTpbJy+o1cbCyYyUZCstm7ftjoBzc2o6/9t5WpjUbbrFVS4ThMYDuZyXtj
+k5V6OzOHQJBWLCzYb+c9sB3vleNQyfU8Ps9lCI1N6PVzkYWGp/clmXaRhjeT6/de+8jAx2bX78HC
+8o5aiMQnk4bQmLf56CkL3X2w2Ngclk9jQVmaXYrdhHVpBUixm8n1e7dWyOzPLg1v/GWhJRYuuB0f
+aegvC8c5TGPhmJtcGnrKQgwJT9OICIs0HIt9mSAcyT76W1MW6mvfK3jKDMPwZELQrx+e5ihFZWR8
+QXp4LNBYCNAoPdf2mJ8fGwu1IENoutCUGORV8OW1dox14/4zGQnpVsW5DLXOXXdPTYvvWfVzXfuE
+03l0ybpILX7LMMvLxUjLuoilO4dYCuFP9jTSXgc+YskWuRbG3r9zxtJPvLis3h6udPvpbxuFjbbF
+pr6XvOdlot0bbGwYQMShPSR3ofzJXjsDdkp+HZDw25CNeagY5WzOLfjWgGKliZxnpyxd8nELjy0u
+Oi9OH5C5LPAbDQp3gWfNlktcLBXwZJY6ZsYdxTJS5tnMoMNTaOaRQ+efQWdkDM2YQ+efQWfZe50p
+hy7lm0FnZAvOmENnAHXNoDMjh2fLofPPoDOzBWfLofMESjLoPLMFJ8yh88+gs2YLzpJD559B58jh
+nTqHzj+DjkixOeTQpXwz6AiUOeTQubAoSwYdiVKbLIfOHpDsnQfUd1ji7mavVa/zzsDa8Y89o10K
+9vSeLatBgdubrwl/5ZxEETxUguJcwrqYzpZdI0Kn8fQCns4miSX33uM7W/GOJQ+LJ5pXNpZlMx5p
+thoiGQx9mSn/Lrns8fk0lp5yfI6ckeDMufDjywatl9BId2TweHUpTOZjgBvMp0s6r9H15ImT5sLz
+mru06ogcniaBKkQoCJFiIYJBflRn2ZuzR3TfZRZmH5qL6u4SdROY7DZ5KMiYvT+lx3hsrmyOKm8r
+KTDZbYJQEC9uCYjx2dedyAyBpoDGwmVouTdmD8ECm3U3ZVchasQm9818DMmzGgu3/iEOi5ZsQX+z
+t+ZIMg3efk568uRGzT+FcRLHWc3cy3b19NrcJB6OM7vjMDXuJmntmpkCOrecPrfGO7HfmpUWLg/s
+YeivTkySx+d/dEHoOLvWrkPzcsvjO+6ZTivv1LSt4faBR5fGVGn/GHjolHcMvDF1wfNH8/iWgmRu
+6Dy+rmuEuCXnPaxbajc4J8bZFLFfPBsLOAUhdL/InkVAkswkg7Rvf8yIsYCMmckw5r0VMgXG3A9D
+CNmY3fFbUMcCnUj20zwMiPc9/9SliHWxezYRlLYY1IDFO+rVxCVLPwK483Dbe23b4mCDjb0x166P
+sedxRgRXultYnrwJWx+es0HWqznTHjjZGgQlynnMkKnBvu85d0a8zTDvXLvgtR+MDu8tRn9kGF7r
+wCw5h3jz0lz23Fa5M3Z0MaweyT0NXrN2PXLfMyvWyLFy6JFelPw06E7ittBMpfHsWpcEOV+u450R
+5Ywgmlofgy6FSWmNhFrxT8NE2OXqGoek0xh0amU+eHLu4iAJ2O3K0CQQlBnn6JJnPjKms03kkfHp
+Ej+ZFPPLsPPzyOhndoXrVEBSnGeXxs/u2GYPBg6PDL8k9wNsOn+PjEFj7OHMbosDT4+MhcOENBu+
+Dib3yHjY+zC0ldmHZnhk3KI7wqehhfXI+JynhGlokwUIu8/VWEbqFB4ZzEAL9MhEwiAmKNI+MDlH
+02EQO/nJ0kR9oiR2Rg5lWcuxCoqmCaMs9w/nkZO4fcX6T6K3beCMuTqcxanjGJoZOesV0xtmaJvJ
+sPTpKV/6h6FCFwLTx0joQnC2YFBeXZjQqUhwXt3Mset9zHz0cbuFChCxJNd5uUDtlBwuVA8gL644
+9lGhLOEdkWVEdoXYfJg+H852eoORETfvfLjZzh8Lmw8XQGNzyocjvovZksBD5MOFjlCdKR/O1JOt
+GXEzjmosHy7gRNA55cN5R0PNMx/OcpORaxLbfPLhCI2NZcTNOx/OdV7mng/na4t5bOugJ2WyDTrP
+fLGaPwGFjokkRwyH0S3DxESORUlMt/avZkmvNyMhr3uzqxO0lfHI4Il3eLEdh/Ec3BuXU85IO7Pm
+2NNW9EVo5r9YNmkmini+8nV7O2LgQ0U8u2zlYQqbfyIOzUgNsQxhImbKiKJ+y/L8DgLGpq6dKyeQ
+j3kuw+rjXeh0Uk9tHPA96ykXRIbP5TRg0k7g2TKB1itpZ+Jl6CbFsJ3ZlyG24iELPU/T8gyzxsbs
+RwIHnYa29u1zWiOOL+XwYWFZoCo9blC7ZqTezCMj9fF7jhmp0Nj8MlIfv+eSkcouiLP6j0h+Vtqt
+lUkzUqGdKfima75YQDp/yN4w4WyxwHbCHANtj+vzzN+CBeJzaGq4ICNr1A0yiPTYMlxLBExE2Ghb
+azLcrBE9rqlwFikWJqLHPsjQqXBBZ0HPJxXOWJV6Mtx0fsuAVLhp7crJUuE8zyCaaypcwOkNc0qF
+o+f1BaiGoRTDctYvt9rGDIJPhMe8OluARJgT4b31sbu5HahGMDYvBzJmr3kcYzi5DvM6sB8yHGZz
+wSsbvZzNhdrC8QldwCw/zUfnnvcaIrnZ0SV/ijCioP1jBzQP0Dm9Nc6VnG3XohfeHt4KlfvadX0n
+NywdReJV9cfm8+Zl5ZMtl3IHN5VF5aBe2U7VLzd7L6k8fNs9g5or5drtY63FrWwtVKgwIu5eiz/5
+ejwBTDrZ1s+50rpiT3ZbvL47s7qvbClgW2vlhzuvZLdbnww7vJuPtY7fkezGrB57AM0v4qXaT17X
+xQVk2PV5b6B4rbYnULxU+92Ri2W5jy/pk+x2JnIWoPa8M3LVtAHUeV0cXo/Z8cqwE5I+GXYLtUbW
+EyhTO9w4cwC13scXF04qL17Jbs9+yW5LeW+gu+eL9z738cVP28cNL6AXPug9Obx2ALVm2DHV6lXN
+PqtL5MAC45uWiTda3cyFqseXGVtMr1dN5mV1rRiixdRab1g1RSeM+U4wFVEjikDfwnERqGW/mPvA
+kFunBgtoFZP2PaJK0LH/4eQ1WfubrqFl3l4T73usPI4S94q58k7tKQfEk7ptfrn4+ma8Sc7WJe0e
+ufF7RSf1LjlvknObulBeuLFDzybNhjQ8vWfLPSbgHHF7XJ/PVWZjwdOBXrhJLpHzHF/gvW9Bl42E
+Gl+YuwbCpqD2QtwzEhbpQSHToddLL+i8fLdwV78L6DSLb47ZdLP7YcJk07nZAW5euNmy6WxD03Lp
+gs6HmTybzs0nqN0x5IXlKbLpnNwJc+nmkvkYuI0dmXs2nZfXer7ZdG6BJBOcEBIym87XrpxbNp3b
+Po3r3utM2XRuuXSeOyNTZ9O5+Vns51vOI5vOM2dkrtl0oc65mjmbzqhsyaVz2xWdLZvOTRhF4vPO
+pnPrkrlbPa9sOrdcurEbc2bOpnObP229zDGbzq0pusM7z2w6N3VwLGdk5my6KTE2YTadP8bmlU0X
+Kstm5my68DlWs2TTuWmejtzqOWTTuTEc+70J88imc9stQRqbbzadtQE9l87bep02m85tnr12RqbP
+pjNnyNxa8ZYv02bTuSHD47asGbLp3HLpPDO5ps6mcxuQqY17KaXYqVkNQLIzUlGdF+8+Dd4DVAz/
+BDEjPSzmsJKmTnwKwS2s2sV87qvz1y7mdV+d2211LtpFODwF3mxrJVLiUfS8Fy5IsQhHApUhQgm4
+ida2cnyvqvPsklukvU+nQksfe5ec0R37ITSAsF0yLcxwHMYHT0qY1TuWyWW3iFz2nr8O7CLBJfpo
+zAnmalc6L7qbKmfNes2dezxMWJU87DV3kRAe44OZr7mjN+UFXNwVLpHOJ0AibHzybNfcmVmcPhfd
+zXzN3WQexWmvuXPzKI5ddDdZrlJ5/Jo750ngrhfdTb55xG9fpSx3sU95zlX/cG55Fttr56GSX4Mz
+iyJxGNxaYua8M/9YjEgoCt2+inuH1ISOtT6cxzH8eD2dR+yvPVIlOMPQO4gjbFYaImaW5Fd7kqFV
+gfamZO8btqwbIMAjx/OJoMwu6ILOhvLa78F0tWzomfSOhqrPLxqqPs9oqHrIaKiAwOazr1CBUMGZ
+j8mZt0JIK47jwF1mP2Q7k4g8j8gu0s50K9DRiiXDbtpcdktj3mcLhriB3ZlY63JAMZRt+kvp8KcC
+YmNl/+QV74iAsYhuaIwLFRlukV2eqPyprBJUTnTfq48Sgdpa0hlBDWWpoP3KcK4/zH4KVN1DZKZc
+9ybSJNz0CGvu29xuMLzuORIZplv7g89QFw0FZz6ur85qB5TNU4pn2q0m7YTJ5wzK4HYcUTxlb4jv
+Yt2eWDHhRTyOBeKWyDD1Di/qXqtjiQwr34GZKSGX4RQ33LnlV975bZFPdcPdPO6tDr7hLpQ2PvMN
+d2bmo/sdd5MtH6/ziqe4KW8ueUn2O+5mGJUzL2mya+mmuOEuEvKQnOluuAt7qjkGqcyOQHIH9zQB
+G64IbCw8u+bCWs4eDJ9Y21h4XZzICPXIfJxDYu3jt5ndPv05V7SdcN4s35grbGfWxFrSCp51M3ti
+LfbG+1y403OLnhwijekmRH67WxKTRYdxLMOMyzK8ndKv5Xrvm/fBMpMmMT2rxNbykmIeaUxeqLz1
+N9vpeX1hDffbKc1211V5G8pNHSaJ6Vkltvs87EpM9PQ34O12pVca08rmtTdjDqEY2rwK2KmQiW3h
+FMNyNkMUQzuUcjbwzu9QiuGdQzF03JQ3aY5r6fbD84wTCyuwnwPvkxEWYBb579g4MQ==
+	]]>
+	<![CDATA[
+	FipZPMTRVNBU3qHDTJ/j6jwL2cM5GfJuwemvezTiYMklefPKcb1zy3D1ynr209HM1cvkas8ZN3h6
+mplSVtVtFtY+TdK73C7cVe5rd5eV+6q6U9zLXx6US9lmuVzKHWIYZ72vC554x44xzbvkuIftqt95
+sOaJ2y8Ke/C+/E06XzuzkpItHy613jz1SsITPyLx1fhGrOeVhuea+6enprVynkCZ2mXp3Ga/OO5h
+s2aJOYG++F1zl5EtQO2paZG4OlhLDQywztQ04fbjaN3jHraFhGdqmjp6YS1JeNpdaRYEb6x/XXgA
+zS+S2/W88uEePIFG4oDgL++EQ6bWu7z0BLp8pHy0vIAqJlAqK+1peOe33kCrJw+7nui1XV5oBQrz
+AmDPx2YVlqYGnnzT6HwtZL11Rz2N84/VFB6PQrUoJM9oPU1MHuVdlM4TI1uwNuo4vSp+fuIdN2nn
+GTZJ/Jap8fPlzpZ7YePH/GTzQ8V5VmdwyJB3StK3f5ci4Ts1USiMfaPLwvkrM4dWmV1yBFZ5+WBD
+eJLOVmJhp47OizeeJgqt8s9Kmyi0yicrzTNC0366aSh66k0WpeUZ21OZJGQzqEsOW2yGVMegKC16
+FkGoVEDvA28mXC8+cVo7tDfjdo7dtM72xpgVuflrHqbEj6r/9mUoH+zMp8ZZMFad2771j+ocdnlg
+aI+z+8d+VOdwbiPMubl6pz7XeiLPMnpHvbMAZz6EFnMAw+aLBVot2Jh3lFYY/5gjaOSV6zlvoGws
+HPmPOSyHeeVG87KRPd3BEzuDaw4O6oy6meywKzyEzPuwK9NBo2fYBXtV6MkQtgCC3eBTF6g+YrHE
+vbPbfIRjuEQyYyfxUxrO55yDsfPHZsuxClLeLN5YegKVV6cUz3MOQmjj9vvFHPx+4lRAc/7s/N41
+fz90KmDgXS7j8+eRmbKyeZ2ZGzFcZ4NvmQnfmPfOeiQ+cWOBl/9OgrHA+33C94ubJ8b4eWJM8Gxs
+LF3YvsM7bRZgWO3Qelfa5FmAYXMAx0/V8Gpilhv17FrfpFmAYXMAKeefNgsw2IbyuB95oixAd1Y3
+ngPoFwfrNUOT36jnjFWYLAswbA6gT46VJzomv1HP1UYOnQUYNgfQy0bW+jM2Kof2FPJSvilvZJvw
+Uj6v27Lmeymfv1dhXpfyRcIzjRku5bOtyj92KR/xjk57A17oS/novPjdgDePS/lA58dr+eaEJ6/g
+i8nvr5zmUj43rwJ26kh49NKdr8KcDWW/1c+8xWy2e/2M7D3XW/0mzuSa29lQ09zr5zW0ldmjbQ/m
+cTbUJPf6+WbdOfXkKdMR53A2VKh7/ULkV87hXj8DO66JTWOUPOW9fv63+kXiIVR2HTs+9/pNlMk1
+9b1+dopw3urniFSZ+l4//6H53V85yb1+nh2Zxw0gxr1+/gOKhEhHnCkAmkxTwKnmE6Qj+l2EFYmH
+jjnzvdfPf/Vq2vjM9/r5Czq7lTT9vX6WuXK51W/qE6gc9/p5kwXVYAOCp0Le6xcUBT2fe/3mk/Me
+dK+ffyuO+/imvtfP1opfzNVM9/p5hpORPRDfjNQJ7vXz31DRb8oby8Od8F4/v/SUehd1/jllifnc
+6ufIe536Xj//fRqSNTCHe/18LKe7TMIrI3XSe/1cswuMW/0MbjlD3oNx5HOAbjn7vX6h1/5M9/qZ
+6Yhuu8NT3cc38SkeXvfxzZ73YL3Vb5ZsDuu9fi5WrmWLOEy0bZh7/fwDW+0+2Onv9fM/z8O4l2fG
+e/30lCv3+AxLxtBM9/oF8rG53OvnNaf0Vr+53McXGKQR7j6+GQ7TMSO653CvX8r3Vr+JTm8Yv9cv
++Co+Tw4zzb1+PskW7EIK7cp53OvnQl6WW/1my0oLq+aYfpjZ7vXzV3PMzPrZ7vUzsO2aqDHFfXyu
+2dOT5r1Od6+fSysh70af5F4//1a8Y65c7vWbOhme5iTOfq+f/61+CGUe9/pt+d7qR/jYHO718w90
+wtmfx71+/mY7xdjs9/oZ/Qq3Kqe8129au3Kye/08eKB2q998ogdJl3xu9bOfNj/9vX7+imEkPp97
+/fwTYt0k8jT3+nmhkt7q56uPTXCvn388sOFRnPFev8l1mGnu9fOaSXqrX8js2sB7/ULEW87hXj9/
+4WB44E3xcCRkx3S0I8Gny1QujEd8mI5dqsOs8EvyZ87h2vXdwwwIvLenLTr4mJC+sPuwlm3LPvFl
+jSEmjNm4EISkCegpUJLV2e2MIMKMsFjiITmKZXIrx1n+SF7Sqx8NVJUbFGOr7+p5LhNfW+ZvjsWi
+mE8NPvZzvVFjZU+R5NXth6X7hdj+MBkr1i5yC3c/8mtL9eteMRKPf3brRyvKRz+Trx99Pxc+W0fv
+O58vJx+HSl2WTx73vq/rbP/wrf5x3u5c7eaOR9fPu8nE83M5lfx5J/48/TpLrb/1U/c7QzVeT6yo
+Kr8UW+gpvVycWfpYT94fNa8BY3LqOLH1vfR1xLTi3Yqqbq+dxVafdo9jXOm0k1pvCjtMjdneYmqX
+NzVmd7F3wuyennyoans7o44+tlYGK+mTVxx4TMu03PqupjalkweckhhJegOMVa8Lz+rg/WCRyZ0q
+rgxJmxeSX7o1GFbua8Wj2mZxs2leAUnvEVwpfV84kEVQFYmvKB1WqH9cLX2rO938Sezm5DBljtU5
+0tFLdml1OX57tiStd0rxs/ruwcpLfX9TkJeP8ykjORSm6bGaKRwt/wSySNVITuJ+Jqa2n3KYwHkB
+ouVUtStbZevyeYl3rIRG1AnN31oyh2ZKH0Pu00zbwsraco8Tqjel7+ud3HC1kpKF11ypyu3tQNnx
+wc7b1eVJcS//cpKSxc3tmrx00So/HSzukZFypbtUlS5rcqjb1u5NAvdXEqlKOj6KxGuJvf19tvpj
+baPcbuRYnJxutfn5LTO5288M97zXSjO5xncGZfwSRkRk8G0QmJu9T377aiFLNmt0zr64QkwhJicK
+SfITMLbTw/UirqVIASzni2/4uZOhP58GSpp845c2Nl5qz8mHQ+btx877zvpRTIV+H9KO0m6mme6L
+8WDV+qAcf43EjUdp66MrtmU8yFofvG++GQ8Yy4PM0v6H/uAkSUbK7h4tNEgZkZUnKUv13R/ZplE9
+Y33QX2OwLKeJBPGEwYSlL3Yvf8ThT462/foj3tAbOE+RKpE4+9pn8ZyO84zBfJaAWBJ4P8x5lrbT
+zJexnXOGHBrPNvdOyU+t2eb9A0vMFCZ3V0vljuufPDy9TJOnXDK/1jIxdpmlUJjkksRwnXq8mpaT
+P3bWmesl69IElkkZKrEwx61XjfNDezmzPZj9ebTIWHrI5hYHG6mrdTW/dSWcFAtPrQS1K0tc8r4e
+0+j37oErfvWOBsXDm5sXk7y45Kj1qQ/8xkIqXGVvEzXBG0rdXOV+n6VkX2meiuRbJM5VOlecVjp6
++EEWO1dNNp61b9y7iE2ItInn+x1s8T5LclS45w6Y7uTd59GF1vZL8tagtnvOuiq5l/XWT+ORkKpe
+3+7hWF4tY3m5iZWRr6zjYcUXpU72fbV41nw7qhzux+qmq4bRD3QsGz66ZZsHXmfHJT4+2ld0oE85
+us6XuSuB9JZfXn8QtW+VRtuox2v1rr+Kjt5E4sXT8uVTrdJZaBYvLh9Xqq+ZnRtTQ6Ci3K5+Q7/P
+yob0XXNIX6fsXX2qAcZi6Y+ft7H09Y9qLH18cxtLntwnUCIfxFIjkGeg5+7F0snty1iy3dmKZbrn
+j7FUMyvb5DXoB8SfSmyt3OZdgowUWFiRsMxVIwparPe1SsAZ4ecd2DdnQoLJDRM43c/DWpU7luDb
+3grGhH7jsZLofN5LkoWLzkLyEz7uelmNL+7Ensicol1ZzqZJCg33NNrYz7Vvh1k6b+30WopoSvzS
+evXAzcIETffkkC574wMfXGnR51uFJFkUMC9ASk/sarEA7HprM6V3+ZAyCOSbOJZDIIHC9V755bPY
+4kr3V9uamNg6Yhjx9RDJ65C1Mr3Sdx4m5/0UGRzBmDZCzKx/LGqq2m45TcsaC/t9+LlPq4BifPez
+1Fno1ti9TI3FJqxt721f8G76nWV/f9miFW6JjwNTRx13Xn49cEnQI7jnL/4gtc2lOXaXfaixr++p
+OyL8yRvsaqlV0bw9DvcP9LG/w72sHq5xifeLVTf1lGES2XVDlz2xeW6IdjjMI6XKSIs7+FFCSuZq
+J7QguXGyhjS9j5R8EUudLyzj03osU+S38KMFxH67F0uqajqWjr2soNC+dpKzcraZQnKO0wMOqo81
+POcKahaMtbpTbbxUP3e637mXneuVi7vi5frPRGX/IX9QrI8SCzsb27WsoYB9k2bJ1d65j3gvbTe4
+LEDJjdJWsA6g5XZtWQV4t987vT31rvac3lssnr5vHBUvK8JS5e18cEGUoEHsaaWiKaeb94sA4LiL
+PHnbGd3hPWA75PPK23J/cY0vV15h4M3nEMONxPUBd1VosS44DTtcNMBmuRV6UIR2KMRxFy8gzlhk
+FzOodEunZzvAEkXxxQEZJLIPqgnkR3layFzzeXVn/fHjORKvZC9e1PLbZvd1IqTzRTVW8ZzuP0Rj
+W1fPq1WHqUAjhEBnSGk3fWvHbIAJmDJOnOFLEi/lF9eOLnbWqkq79JlInFf3ztrszncxV6zsf7UH
+IJbYkrYWhUobuMnFEFflSlbYK36Z82zzWk+M77DYxp0RzQLDY0LkhdTWaDnmOfQpBw6zH2rosxEa
+6pYTDN058O31rWUrl0c56+iNYYm7M1ILG11dWdyIpb/7R8hGj1AXOIQHGRWZZx20gh3gtKuldCwj
+ZX7Y9QMGK2/D2idqguXIonksdgfFa164ubGZa2Xn+nBzv/Y8vIxVX/KnH2QGUB8LXuyz8jbQYIMH
+PDNv0zm/74Ddhkt8HDCn0khTId8HY2lBBmSSJz6nSQZmdr1UcVtr43lJf4LNROIzs/UQMjwcjdml
++OSQI/E/orQESbFZlBZPRJMzuoMGPMlwXQittOL0jc80yZ7rinBL28qakcZctTWUYtPwFTQLrr/N
+KBeHWUBeK5eyDFe9Kd2dACWn+8xOsXl+Uqtsp8SDYrq3tlK5rw2fiMdt5+2yv15Vn15Pxc7rj6XK
+qHF2upNTh0ullxOuXpMXxS3TH7c+et9Kl7KCes2tbK/umt5BupuQ0M8fyy3hiqc+Ht0/+AKmWX5x
+UE217z+Kl9c36roiq58w+thH4Xvv4qjaaKxkq/ethQ+Cd8sMxHtPZdQPOOBjpTt23zZqeiJfMOSl
+JdAkvh9xDgD95R+PnnoUOeXMVCcGJ9qpY1MAveEq2ezGDfDzJ3Zn/eDzIqwOQ4DalYiptCfQYaZW
+HMOLMhJzFUp2h9Oe3LEdic+C77Bjnl6KTSJEI3FPMTpHdQl0mLnoD/6Q0Ts6gQB3hRzMX+dlieN2
+xJnFNMMdBhPvU1lJE+pthTOrnowdeJijVPG2xPe21soPB/pC27xwIp14f0u3rZHPpg==
+	]]>
+	<![CDATA[
+	1vZ7Ye3p7FgG0ZHHg1I3SpE4CIrFE1KwsZEZboAE2T0C0VM/2skNtw+Le+JVFsTNdR1+MrW15V5l
+rbLYyjN/RL5MyQA0dovz8gfM1RDyZVZDuV8ulz5Xuo+VbGFlQAQryP2QovX/X/kyjWSLxEMM2HO4
+wGH6SyGcMTT3bU6TTJh6ppuROg6/AMqX6YX6+uFS5bGyu7v5CXyF//YcOEDxUqKmV6HGFhfYLxPN
++XQkHolP7wYLD9k4pTnc8ppycUXi8+YmHnxsJsUx3HA1Ggu7vKYcM3CYSZbXlAPXaCzs8gqxuHDH
+6s4a8uQadZOuXHDo0juJpe4TO7FUR6jF0s+tA/y5ghuCT+jDO8F9k3V07p3Gki9vkrZJ+NziY5kD
++c7h+ovEHc6/aV1/vlodyJc5e9vdFDqY/Tn7KcJ4SKbYXDFp35PJ/lEb2dCigZLn7KdwG7i2l/QH
+jBirDYU0NpUrcnof7MQ7Ht769BT+sWk8czbI0/rHJqJ4tF79TYk/6IP1t99M/xiNNJrKP9btq7XL
+beGWmCQ1eWFUmMhWcVvlqFs61/lKotyOPSTDLnEq3ug9Be38DY0V0s01M+s55EJjV5Rh+aPwpITk
+bd+kFfwGmtLNw+VynQa20JDxiQX99sXqY/Hy6uePkFYS+UZDMdfT1ENEnKD0LOwJqa1Ye/7srNaK
+ncZPHw+JucbINxI4OYhtPumxuo3vXFgtGvdf/ujEk2knp538yYkn044c5o9OPJlsIiv/5MSH2uWZ
+eeLJtBPr9U9OfLg9vlknnkw7iYb6kxNPpt1Y+39q4oM0WP+J11T74XYqRLS0cbKxEZhPN260ESRt
+pMT2rVP7Ka8aYdZozhyJzuhB/WdC8yiaAYhEyqU269WWrhg3bakDRJJuHN6YkpQrX74KZjdJGd55
+c6w38BK3Z6NjE6PXs2+LFrp8zx1YRkDKYpt3X4Z9emW7wYXM+Z3VGbws9mo2Hywp5fcfzCbq9std
+aJiqFgRYe17hkl+lAsaAJ9jdH+8M0kFSK2t8r2pln5jDi2dUikZIamvMQKLx9WtsygijX925WW0Q
+ssDAewybPOvReP7E9kPHsihIrCq9yYhcKmTcTPNkWdPrnasT7OgCPrizX22TMOflNtbLVen9RWrp
+7sFYlR+J16WLR7axIOzCerFfbaTf40AwNoqZmQ0xYfCwrK+rJF4KJS+avbESHzmQnqJgh9c8JBQJ
+8Y3Yi44EIWciAfvz6TxAnXKvyqBuoODRioLRw6mBAnpFlSUWLh0CCfzOeSJBkKCOGtunNhSsDXQh
+QoHGzFueUL4EI4GeV0iov5Q8NOhg7ym78PMqBB2ALQbMh9GIuHD6qSGBG7FWJDRPj73oQDtIivab
+ez93IyTAmH8TBjV6NuHfAEqSpObtmbaJ6uPWqol+z/WA8+LVRGNhNzVLH0yCxFU5XROl27tMiGGQ
+BogUG2+CnIw7wzBo/plBUmRfbEKimpwqSUSElT9Z6XKC1W1pwEKVegMUY6GbIHQ5E4dJWOnS2kTY
+2UhYqdLWAI24c+uFswmTLr1nY3vts6s3sGqZC+pRTFjpchqiSvhTpb72fZsw6dIHlX4iz8otmb1K
+/dW46K5rr5k0iY9cT2jUe3LWC0djPqNKWmlsAsxaaCzpRWNh6Txp0piDQOw05jcMqzCelEAojSWt
+NDbVMEwac6PzMDSW9KKx0H0IJZFjK5XHc60JbvDD3sRqCM6HEtmnF6smXU7ZB7tEngYTq1aq9KMI
+b4m86kmXIRgXaWB6iUxMLuWnktNMM2uKtC2ruZVrxpLtz0Es+aIMIvFYIvMCBdX6V2yhXFwwrESX
+5BZrO/YcK6qcT5JjtbuWRKX0GA2WAsy+xOfaW7UiX7xuFTV3ymY/ricKokX7UylYUmyNDFjTwDPO
+6rT6Nb8pUOhFesxG/lzb4l5WS8fEjNayKoeJHGbLZY002BQMQynp/orkQSQuncvSbq14Xn4gCXkw
+ZZt7qrq1+VrZTtUvK+W9xyf/JD2XI7VsOY6vtwz6xl+FvC2jGg273XrXkoiUE7MrpqGMmO+QJlzM
+Y6sHWrfYr+j5YyeGU+A0f64sbdEsx9I9v2c6Kwonje1NzbNjPbHtgHlbe99h0++DGt7IUWDeEjUY
+y/4Sq6dr1fs0Fi5rB3VOkK5PHsHttUTSk8cfVDiSapw7rn/zgJbNLcJ4Ae/PWba59LVLcGw5S20B
+cVdgDs5qWxrdvT5l2N2rr4oW0WMb2vrT1/OBmbKNhJbQjOfbTy2Hl2LbfvfTNtu8WC2y6fJt2ZrZ
+iqRrG2lN80PQgzdUzDVL5AFtD1m+lLvZ5Spf1WNHD8lJequ7bDOzyeNZ0HJqq7MY45LbOwIMXZG0
+n0tZFohzX6XeF+dM155TuY9eYgeTjtct5yYgDZHJIR6SxwFJmmMO2asttvlQJUlzLLvL3lbZ9NUX
+xy/zTC3XFte2mYOfXZ5Ns40ddq8gn9Kjk5lE9h7eSDLc897PEl9sn+TxjUquffejwiX3ahLe+8bu
+S/xyjD/QSOSqVeSXb55ODJ71pRG+KCTNSSazCuM7ThuTnDQ8SdaDIhDv6IPVeIPzkemRosmKXmnz
+IZLmI/GZ0+ZDJM2DRJ41bT5E0jzM/qxp86ngpHn9LIIZ0uZDJM0Djc2aNh8iaV47EXSWtPkQSfP6
+eeMzpM2HSJrHXZ4Z0+ZDJM0TjM2WNh8iaV4fywxp8yGS5rWdxFnS5r2T5tF5Z5wQom2frFAlarUo
+EZdXUl85Zz1Nhbr9TFG0lW5/DNCDm821F86WwSL4GiJjHuhcNUu9NOQUQsKOqEROmgyJBWkLslLc
+Sxu4fYR3rnHN7hHJvYOXMGTJKYu4zvEgyr2cx5Gje4x23rhT2yEsDHPnndyLJqeX432ty1s7hBUm
+NB65tZ8z8tJtp330y6ApVQ42egxUOmUNIv9Bp1vLS99c1ccH7ApXDplfHEaGcirK1vprOY1Fabnx
+CvDkFmB29wLsSrNtYPUxLSK493+2IgVJykclUZKiuYtRR1FP1fZ7uxtNR9YjueI+y151W72aqiiX
+yr/DSq85+lK6w+haNFesl/f3JbGiNHstJZqme2IFi6vXUDqcxz/Z1HFCX6XKm7z7ubd4sdmovDF3
+W06lP8nvbZJ0c9D3U1ufGzStMv3R/sDoqSwep1DHxMlKLMMcc0SF9zzMh25e3ee/7jcyL7Ve4YZn
+WlZGRjLSiD5cTPdPDnYO5cGWtLdxk6317oXrqvp4z1Tua3eX5BQgomiNn2l4JE91PkQi01jA8R3g
+xzrm0p/BqJd/uJwPMZ5fPtyRiD/bnGibBGssfT1SPrOyeSfqC++Z0GlGY9mgTeFPQ8jhSRHaN6D7
+2qiDJ+bhueF7lOTxDMg0WXZ6nMJbOZula05/MWeuSH77ul/Sj2oQEkZHn5hWIrGmP1hbNR9Y1RlY
+UxYqfgIN82hLf1TLWh48jX7smAdCmA+s4MF8I0zJCnl3J2U5heKHFfZuLWOiFRB4pULZUU63BU8Z
+5Ecpyrlyu1ccsRqZvcZQ1ho4K6ewSlpTzM/2M4a1h8fF0aVydpQllQDALSzbswsGHSystorPbmmz
+sF66WTp/oEEndbVgP02tPVAT1zWgd6dZDQo1FJQfybfyR752WupIi5KFJMnU4nYnbcx5god5mtnd
+Rc6tvUh8+havGMuqvNpcKxevltdfyh+Fw37xsti9IauJKz2s/jBkfvPWkFaXvEFeL9b5fT1KGxPW
+AMGRBeXk9YIouGm8wjpJvzUWron2iiivEz8QngKO9hWxSchJJ+SbNrWv7yJZL5qQ+7zKoseENYRc
+xvAZZGDBlTe13nw2TP3llRxYEonrj94F/ZCTe9GiGGxf1fZ0+/E+U8k1NpbX3rsrV7WNqvDT9Pvr
+ttntuXaAMP3QDjM077A62rBS4/AhRzR/6HdxlX6rPh6k6DdLv4fvPCnTvRXW3uTvv/Y6lbf44JJk
+pdwKxcNbZtHKdT1OutMN6+tvz3NQaBxYPl4eAadVbiuLrVEVMPa0e3G79nTaS5AjxkrJjnq2kxvm
+90pVJnu5fn/U3drtXN8+FvfysVczWGEihYTK/ClUkokUEmrrT6GSTKSQoOU6lUoykUKi+cUnV0lc
+FRKv6AvrvbUE1NgJxmPq8YlF3C5Vf4hGuMG5zWdJz0PMkIgFPf59uSkdjgU9DBMDo4mz8aCH1V0S
+rKqHVvRWx2MzMvSmBy3SlkvId7wtOiO/GIuXlio+4R2l3LG5g87WbndZ06WocTlUfWjUcK69dVUl
+9I1HNG2RFaGXXX/rZXdqrn3aTZkmOzmsybZy3DfcyXY73XvxizoggoBGHWxyHoEX5FAn9w13q198
+ug33ZNjAC3JfCkYdOAMv0DWpIeGHFQnEva3FHNxbUQC9sUX9SH0z8EI7G2aywAtjoyasW965u5sx
+kKABJUjQpmQs+mQcBZtDt9gT0GDDRp9sr50Npwy80PwWeLvCykwxPOgZ9WwAZj9ME4PP5Cx9wHPU
+Vr5XZ1kR5L4C/z6Q6CG/YdCz1mdAJej5Gf1koGmHQQ70DexDJO7TxNVabpZoHvROMqQB5GNTNcGm
+Vz4SjrAqz7WtxVs5VjfK7mTYJtwbkIers3EY1BRSrn3woohIfAwTR6l0YBPWPow1cMVmHNOpyUrr
+bDQ2Tswm+IcOK1mb+FEIQ1SOPpAIaKOJ983cLGuDqFBueIjEQwu9zNI+S8NWF3b3SnoT+cXVB5X/
+ttTbLX0ntXq1n6yJsfxiXDipvFhrHi2sBtKY36h2rxIWrmOjsbCIAe3QnUC8iDQSd5Lp7rvgJJHJ
+liuopE4C0aMgww5jb2knN/lytdHYXqbGzDSMvfwR60FjYVf83vYFF9AHdSvHGg3sCcPs1YZVIuNu
+RzBR+fXh9T2V8uyDLpG9eqE10WcnIypHH3DvZamQmWnFNzObWX9UokT2ZVzNfHkqrkOMbJFNkPRE
+bVU60hjY1GdhBQ2DH7qBeNw1jK9n03+S2jrrUA+J7g4kR8jSqAJ6hKx+Xz0awJrRDLDpTif1bIkF
+Gk6jHaIqbtI9QdBgH1T4Wc7qr9Vyxnm01g07EKfP5pnWh0nrI3lo7K0dWvftQPAY+3aH1sOuQRoY
+OyCHObuV+26B4jgrFj2cJ9YtSeB9xpbkiXVLEtiRsfN2kiXGDrIHujGEqxwJ8oTVvKP0rNgt8dza
+NiwBxO25dsIt0OKaZjakj3vUqgbyQoo4z2knbG/vI9rOWe2N8yvSKJH7ixuLxA1Iduo1J2FGQLK5
+tCAGd+LXJ95qio/fkWgJ/9irbUzZolt7kTiXPD/aNDcIxOHZkrL7dC+9F+ujpXb1vnWGvpRL1qRf
+q+P37gevk9elYN0W3C4YpHKT0eaFq5yXkUHc5HTCv2EwogEtxxtWdxPdkKiJHn7jjW8CbaC6/oVn
+899ntK3CJpn4+5xxA7N4z+jt3LPWjUHuh+HLvOetDyqfS5rn5vOnaLgI89Pt7pofzg==
+	]]>
+	<![CDATA[
+	vdgni/OHX06eIlKf4OPuBt0IT6zxzXYKOL98/C5gqeDSn/Pay/VduZKSkrVa9fhaMmdVD0Uykowo
+Rg6+NKZQe05qJ5oD+zggPtqUXun6G2kni8PA/ug7FYZ3TTtKGtgRdcWtFjf7NnZUp9ueaPt8E8wS
+PraTIRlGaI3cw5K7VvUTqgtaSBrYGA+ud6KB7fDoRC+J0gAWljN5l77/AtwrRRmX3uUnjUdulTPU
+M/c0eP2kB03bGBdjHnbt2MIwI9BIpqBEt6GRXUnGcdcaXwFOldWYFOFEoMNobr7dU4a4Q/ml9fei
+3jbZwjgrw9QN/s9WZD0Sx53A52q3Zd0FjMTjUFJXhqM+VhCfS8p7u3vU+K2oETZK/2PgP/wsyFGW
+k6KcKMIPEUuPXiOJwa93nmGEZPSoG4k/54rqsNJuDtu9bkP9HV3DotvjoxPcXyQ/Jnm4Hk38+9Xp
+wuNMYzhU26+joTJI4j4lwlEbY7WaH+1OS1W6tA4Xze13h+ZT/Bj+7iv0aeJjOOyv5XL9kdrJ9tT3
+XKuZUzoKImWQY7NsLhnN1QFo993ewq9GZ6Q3geWDtVbTo2q38aXV1PpI66b/K8bdVJXGsP1Lafa+
+vnrdAUFBd7AYetTNCUbd/K8Z9T///JP9hyeD5RhYOUC9oUfsXddlyKTyf92YWVmWcwyX47iM2nrL
+DH53h41/M5NMO7wWHgmk8n8PEtrdz0Gz0VcorUN3B/1GUxnk9PLQSAh4wQUT5hv/HegY9FrtPvzL
+Dnojtam8AUaUbFcZ5iqXFeNhhsm2hq3w60N7bYJFYrzxH8YKYYY9NRuOHejdXmv1mnRUwQMef+c/
+PGQmK0hZNqrKhTwTYsw6Aa/9UtQBdDLMmMffSc8+LNZ3WMEDqV/vPl9+tAdVKuvDjGPsFX3qrvYr
+0bWoqQJBXVCymGdQguCR9j78izDRIvy7/ScyinzDP/1zFLny1pm0xqFpQXpmn31bp0oaQPgNPw7g
+y08o+ifKMtHj6MMTE20h9IsIqdKK5KOJZPT2xugGG63Ao9MIk2UYNl+QokyWE8QCD61mJUES8zI2
+npXlPEMeFvJCgcljLVGQGS5629C6wNEu8IwMj/JSlC9IWYmXpehXhBeFrCiJUV6Ss2JBZqNHEV6Q
+s4WCIEQFhs0yhTyHZRyTFfOiQOpxgoxFIpstyJIUFdgC9KGQJ68y2TwrclGBE7NsniXNsRx8lWXy
+qsSLpDV4QxTYqMDnoUcsKWOFbF5iCqQMhkFeZfJZUeQLUV7msjzH8VDGyQiNxXpSluEkUiaJWRi7
+DGV8lmEL9F1YSSygg5fZLC/nEQZX4LOsLEike6JcwJFxeXiXy8MoEL7AEhBiFl7goceFLMsXCqQa
+m5WhowIDo9Gq5QGCLAIEScrKBZmMAlEmyYhiwKdASrgsjBBqFQqAOY7TxsVJ0E2cCJbPF0hZIVtg
+JYnUEziWoHhswo4ib+6UWdCWH66J+gcs7svfoaTaf5LTTcLemr1uV2mCLMg0R+qvxnCkhmLv/u//
+v8n2+o3hB8+IeX/m5MHhEkC/5H9RZuyL8YgVClkgcB5IHlZeEl+TCgzLcJbuF1u9V+X09Scg/bgB
+Zf9q/XTSnxP+UG10B53GUHlMaGCENADB9h+TlvZJPdCPvmx4KRpTiO3aHpkFdi4uChNxcRunDiUm
+RC4IADBNwWTTDhgMkQKWPhh8x+CAJhu3MEWDs5t8x+RYLmWWVz8iN5Fu5DzU4JjAwU2MMCGAdKdq
+M3CWp2gzeGKtbaJcZXmQPijNQGQLOG9GWV4CASvAdHEyyjL4Ao+I9AUkQ/W8WdAEgcdibdks4/Ic
+fBELZkNmiQ4O3tPLBDaPUKJGQyh1QRKZ0IyCZsTokllJ77bezvjYypE9oKKTcFQkBFNRtiDOtgz5
+ybS1yQFwk5HDpMtYn2nrMnYpm24Zs/NZchMwdybNF/LYe174M3ydnWzFjwxVmynwwIkRmwzDo34N
+urYsUFU7L+W5AnwRJQYoHb6wLGrdY6o2J4LWB4ohtMflyUIXQUdkQSE2ynBqQdOVABgPeqkACigp
+0+vlYa3JPJZpjVkLYI3KoCLiiywjWyqZrf9VFP8qimEUxXwA751FURRBgQOzD2xRIc9riiLwJl6e
+r6KogUkjEGz/D3EUMUCCyBZWQo16ukWD/90WwZz/iZgpMGA9/vPfwCEGfznEXw4RhkMESNK/HELn
+EPlAFdCmYxJvoLciMg+fH9X4UWXPC1kpz/Ka0cHzolmEjjswCBkRmApgShYEXvOMMQwn28uczf1V
+NP6ykZBsJEB8zsJGCiDaeBaMPLB/ZMpGCgWQcsJ82YgGJo1ASPt/iI0EWGOTKRp/ngP8VST+coAw
+HKAQIB7/cgCdAxQCHWJhFIn5byFyYJBwebIjxwJHYNFwIWWyKJN9MCjPR7GkwJCdMSEr86IIJQWw
+XyTgGhKbzTPAesrASXh0n1jKKHfhBGxfAtYjStBWngVEQ+ew9XxBlCwlMpcVGI4njk2tjDgk88D4
+0LMpCFAdnZY8j/5TRqQbi0YJdW3K+by1FrDGPOiKZktGiQWeWab3inhA85Js9pwXJMALOmnNMfMi
+D/B42Tpm9PDlOYYl2BIFfAGsN4Yt5MkGJHH+QQHLcVBFZsCuAzyWyf4rm8f9TR4YMt25BQuPlYFN
+87IAdiPdB8VXhbxI6zFkD9HSHHzhZWgE+gA0AKBlEANgNJKSfIF4dGU6vQiSyfKijDvDQDOimNe2
+gZmCwJGdUYmle57wLs9wBbKDDNRG9jdx5Gi2CgwPeAXawhJAH9ZCY1WGSYf+FwTcF2YKuBmbR5gY
+DiHL2L6EbZH9UygTJcCYwDJZkdPGxNJNWIGRQS6JnFbG8UCkAssCueN04QhQaAksj8ROXdl8Afd/
+oRMs4A5BAvbQJ84iwTAUIiIUN7ZZ6JnMCVovOIHVyriCrElRNs9jz2QgP6jHCyL0C3HBwXxJLNKF
+vtPNAcZ44ivHjXOWbpzDFLIywSywGIkRsJ6QZSSJts9nORapmkOioYIbx8ZiEaxDVsYh4SCBIgSu
+kAUeBSB5CZqCLwIn0w1nAMkLWVhpIqmVB0ojIAEr5EUZ8Eo8CTxfAHLGV3ncpuIITfEivCpgGSId
+lhR5kcNRwheO4bEEHvF59GUDMQBJIUiAJJEZ5zljRNBrwKdE3pR4jsYHwKoUEYsASGR4Wg/ogKPh
+ASLPwShxuGRyeeQtOG7ACVdgqfuccJEyCVzI5wukJeg2GRFODUt3OCRJJOMmWGcEIju02AN4kRXI
+RghwehGVIBZ6wALOBcQvhyoQsAhYwxwpKeRhvZVJuAOQK0e6BURBaBPIj7BT7JgoaWWEAKF9mD/N
+a4P1CrAIsUhEUYYBAHkKEp4grWGYAPBRgZSQ5QYgYf0wskhBSsCWSOgALi6ZgoS/hKCgHltgtXdx
+OdB6qCeSIo6BFYJLW9AAUE4qQwtQnZTwEoOcAKMwOBb5LZJHnriTMGyCh9GRMlgseVKWx90k2hqD
+84dlwOZYmSAtD4A4ZKsF3PXARcDg1pWM7neCQ5gqrAMQMUBFJjMJrIqViLQA9pinUwmgGcIbOBRC
+LB13AZgoKULejqyHx7gT3PUSMDaEIgzoEPoggVxHpk22uBginqBIwCgQJHLSP2wJOlbgKeGLsJq1
+MhE6QDtWIMTDFQA4kCIlahk4JlcAMpeIOAIexwI5cQXoM0gp2j6wOISJWyI8WYBAmyIViQUBdXme
+lIlCQdACWUj8DFkoBVoNBTK0K3BIYwUEAJ3lOcoGiKDl8kDdpACWlVjIE4jQe5bV2ZMW2CJhSAxy
+BoYGsXD5gl4LxsMQ9sShtxFUIMqypALuOAICBMQYh2iSsQTdLUi/sHbyMlBcmbwHdoZEI24ElkJE
+gYH4glVBeCNVBfIom1AQF1gSEINinuwu4rvASGAq80BESHN02UGBKCO9s4TnMzxhAtgUdEcgcgVo
+m9ea4gQio7RxoIcU99OwuyBrJBLRxIkSigeRVJMZQSKqjMTAShEY6AN2AZ1LqEkRCYhPymQ7jgTs
+oPQE7iForYscilZYUJyo+WmR++V5IlHJkqdlQIoyqScUELFQgnICsIELUIhqKpdABD0nagA5QaDh
+TrD2dIAckhpqDazI643bFbi/Dpy/5ls48036g35gYBQg7PKg07Gw0Ij5BrwXxMx8zTcNTBqBQPv8
+n7HepAA7d8KNor8m11+T66/J9dfk+mty/TW5/ppcf02uvybX/3qT6++O2V+TK5TJ9Qf3zP/fMrkC
+A5iDN8xCRXkXJouUHhEjT9+Ek2VeJvHDMlrTuM/GiLLMFMjs8DgVDFo0NMYYmDjqQJh4RzblxtP5
+gA8TaQAqOWiCHG7sw1diLxllR5YyUG1AkvJaGRgmecJ2QXNHvQdVDk4iJXIBVInrCJaxOm9maCKg
+VkT4G02NQx1HRAmKphOIYJoHB8Kd2FcgLdmCpcRonqboyUSxgo4xEoY0GkOCEqjJkU6A6lfgRbP7
+4wO/i9T+MtS/DDWYoYKu+wfT4tAiyxdEmYevecJQ0QMDpuWc8+IoHGCpoDmji+ePsFRQ1qdPmNGC
+GO2erTH+xSHrkcgyBq0K2RcjkzhNo4hyKk5zMQgkP0mvguxA5jQ2BZq6pHEIdFM5m/7LIP4yiJAM
+4g9qXLheZYZFI4XlRcogQB8oMHMOUtLgCMAgRALgDzGIyXSuKRgE+sHkvKYzgL70ZZahAsKLIlU2
+MO8BPd0yY6TN6WVEwZGp0jPW3t+9r79sIRxbYP9g6CIroMeKo3oDT9kCiHdp7myBwkG9gScA/gxb
+YCeLXXSwBfYPGUusYJzfIYp5aitBEYO+MywTROLyhjJeRm8jcdJiiDS6x+QCT0p4Eber0O/FkU0U
+raRJ3MjQJcFaC7qJPkFsnSlIthLNAdiMGGXEaUW8zURjEUVSwmCvsETCPT50ToGBTnzsWIaeMFKm
+sTwok5k8dXaJ6PglJRynubXQNcZqnmZSILHElU2cdhJLysjmEJYQPzwpwe0QLOHIxpQEmBao052n
+PkX0kOG2CKKOlVnNQYZ7A2YBi8loAhmvXiblsxJ9DSavQE6WAbQK6KsDe1IQ8NQTvaRJbV2WbGZq
+ZejmLpBdD70ls8SEZykjXjt0oksMGSx6diUJSmSgGU4kY2Pp/hdanJxIkZsXRWpxShyauFibw9p6
+iXUyzTJtyknjosSaZEGOr5Fk3ko81LMvCNZaec35S8gwSk6kkWWNfHH7o0xPqSnIFpJGPz9gR8SN
+PhntbtwXlnF22QIZMMPlZWuJBU16mYSbShJFlCDl6XE0XCEvWKZFL2kSIiBmulmLlel+iNGSWWIl
+A6NM6xXPahkGtOdcPjq2Yst/dfi/wjqcsP6TZ9/gxoAoyKBGspwmrAWZ5+Z++A2BI6YBCGn/D8nq
+P334jTypu5Qefbb657ymoAQxJJAB99UEEKGYDsVleZ4nO/xkNxQ3+OneOpQgP70m4Q==
+	]]>
+	<![CDATA[
+	AmTfk8MtV5QAHKPFUkCdAgYB3EV4DuhExPNVoBZHg0FwYxm3oOgOIEoVAk2mp5Cx2OY16RUrov6A
+jQFrj473E30Y6P0goSUkAIJnJc1pQrbpWeyrZumg7iDTiBoa3wImD8fiRjfG2ECvr4k5hGEnWCKR
+vXUokHBopHEBYN+5AESbCZU07CCNZRAxfEXS8JgX8DA1Lq9pTzxYWph3grVkCRPScUNYICNFmSaR
+EB2eI5tt5DUcM4+YwZAPrFQggU4gMUAA0o1Uiaeb8FBGI0T0Mixh8gztlCChMgElbEGmM8LKDH0P
+H4q0dY5FdQgGR3en9VpEycMIB1JHzPOa0kWELymTUS1A7YJsCoPaKKGChCfW4aYrbgkTD1SZnmIH
+QyThHAUMTyAOKxqcAAjL81Q3BHVM29HGHeQydYYJghZIIQuW+cE4EgbDuKBpHnUf3PQmO9A0NCHP
+40xD41IBw6MwCIEn2+qAZxm1TQZIhUONg2dBH+JJcBODcWAkYEXSTqxjQKkVdGomWhSDO52owgKh
+SzSMhkGjIk+2pDncdUVooEJr8Tg4dVBDFsn2MGhYIo33QQcdCcjBMi3EhWhNslYP9xYQnCij+gTz
+IxJFlsHdaMQT7lAXaIgUlhH6541oKCwiKxq11DwZMactEg7VPfKbqCe0QAvqQFoXtTJcs3QlFchB
+R6h4MVSF5uiLPK1NSlhZ64Cc1yiFeh9wbYnaOYgMDTohK4khOqRMXRM4YI4p/N/2rmS1YRiIfoH/
+wRdfSkIkeYlFT21JoBBooe0HGCLSQHCKHbr8fefNWHLT0JKQ5Jajnq3FWmaRn0YMKMv/3wEYMUZB
+aUOXo1ds7jc3rGKBBR4ADwwZmgrBGI2S8IiYwOJtAMmVeA2FcAOBlfjFzlEX844/QM5QyZQb8kXL
+/h1ZaEy0Y3bCGLsvWGhZIYhKEcoQi1FjE1Z35B1hAulUC5aXTPWDqyVpheUJjotmxg0vFZIpWQGi
+CgrhLoGUyYwUYWniM9IRI5SEtpB84xTzGQIYAiTL+Agbr0waSRvviCuYk1d/6LCLRXmxKLcsSnPG
+XWGDmKFkJpDS1/lYLEpw6pQ6rUXZ1WMGVAtXcB6T0hyxK7yPSanNYSEHhcDEzFvSBWmhwZ8OGHhX
+8EnBXSZjJWMKsc1xDh56tGQycod0unULAzMTEhDMwZATAXQLcEB96T3i23AX7WKzHoOOIA+aCvWl
+gzenNXZnfBsC8qNdAZtF4YsCFr46lL7bN33YPvv/mOw1tQPCsd7kUHZBCui0E/vcoeSo8w6acSPc
+6IHbPKilKh5NG+de6vma3ucUSZ/7eu4+Jf1EUvTLp0nGI99NvVlWq2XV4jMG0XX0u4bZrdwKMqnn
+fCfIcBglyWO1cM9NtVy5Jlq01buLq7peb6iL3uhJvGhcS3W5uH1dfwChLP71JJk8TKNvOWDeIA==
+	]]>
+</i:pgf>
+</svg>

--- a/misc/openbadge_badges/badge-learner.svg
+++ b/misc/openbadge_badges/badge-learner.svg
@@ -1,0 +1,665 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1"
+	 id="svg3004" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi:docname="creator.svg" inkscape:version="0.48.1 r9760"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="108px" height="108px"
+	 viewBox="0 0 108 108" enable-background="new 0 0 108 108" xml:space="preserve">
+<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:pgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:pgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g id="g3014_1_" transform="translate(0,376.07634)" opacity="0.64">
+			<g id="g3016_1_">
+				<defs>
+					<rect id="SVGID_1_" x="8.996" y="12.472" width="94.089" height="88.952"/>
+				</defs>
+				<clipPath id="SVGID_2_">
+					<use xlink:href="#SVGID_1_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3022_1_" clip-path="url(#SVGID_2_)">
+					<g id="g3038_1_">
+						<g id="g3040_1_" opacity="0.75">
+							<defs>
+								<path id="SVGID_3_" opacity="0.75" d="M97.635,57.893c0,24.043-19.487,43.531-43.529,43.531
+									c-24.041,0-43.53-19.488-43.53-43.531c0-24.04,19.489-43.529,43.53-43.529C78.147,14.364,97.635,33.853,97.635,57.893"/>
+							</defs>
+							<clipPath id="SVGID_4_">
+								<use xlink:href="#SVGID_3_"  overflow="visible"/>
+							</clipPath>
+							<g id="g3042_1_" clip-path="url(#SVGID_4_)">
+								<g id="g3044_1_">
+									<g id="g3048_1_">
+									</g>
+									<g id="g3046_1_">
+										<g id="g3050_1_">
+											<defs>
+												<rect id="SVGID_5_" x="8.996" y="12.472" width="94.089" height="60.786"/>
+											</defs>
+											<clipPath id="SVGID_6_">
+												<use xlink:href="#SVGID_5_"  overflow="visible"/>
+											</clipPath>
+											<g id="g3052_1_" opacity="0.64" clip-path="url(#SVGID_6_)">
+												<g id="g3054_1_" transform="translate(147.3794,85.8701)">
+													<path id="path3056_1_" inkscape:connector-curvature="0" fill="#6ABEED" d="M-89.623-14.21l45.328-10.739
+														l-4.811-11.497l-29.209,11.827l31.233-28.749l-11.184-7.164l-28.445,35.326l15.784-46.417l-13.273-0.455l-8.127,44.384
+														l-8.562-45.706l-12.344,5.011l14.763,41.621l-27.216-34.201l-7.569,10.913l30.339,27.546l-34.05-15.046l-1.419,13.205
+														l40.594,9.439l1.426,2.298l3.771-0.895l1.432,0.715L-89.623-14.21z"/>
+												</g>
+											</g>
+										</g>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="g3058_1_" transform="translate(57.3389,463.82834)">
+			<path id="path3060_1_" inkscape:connector-curvature="0" fill="#0095DB" d="M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248
+				H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3062_1_" transform="translate(57.3389,463.82834)">
+			
+				<path id="path3064_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3066_1_" transform="translate(72.5313,439.77264)">
+			<path id="path3068_1_" inkscape:connector-curvature="0" fill="#6ABEED" d="M-61.955-354.134h87.259l-2.13,6.917h-82.202
+				L-61.955-354.134z"/>
+		</g>
+		<g id="g3070_1_" transform="translate(72.5313,439.77264)">
+			
+				<path id="path3072_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-61.955-354.134h87.259l-2.13,6.917h-82.202L-61.955-354.134z"/>
+		</g>
+		<g id="g3076_1_">
+			<g id="g3082_1_" transform="translate(63.3096,106.6533)">
+				<path id="path3084_1_" inkscape:connector-curvature="0" fill="#6ABEED" d="M-58.546-48.095
+					c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799c0-24.262,19.668-43.928,43.928-43.928
+					c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669c0.656-2.941,1.054-5.981,1.158-9.095
+					l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66l0.715-1.86l3.229,1.242
+					c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665c-0.748-1.979-1.618-3.899-2.604-5.749
+					l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209l-4.565,0.718l-0.311-1.969l3.411-0.534
+					c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119c-1.622-1.334-3.334-2.561-5.12-3.682
+					l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908l-1.251-1.55l2.694-2.175
+					c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952
+					l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314l-1.859-0.719l1.248-3.227
+					c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626
+					l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566l-1.969,0.306l-0.529-3.41
+					c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053
+					l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609l-1.553,1.247l-2.17-2.699
+					c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394
+					l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+			<g id="g3086_1_" transform="translate(63.3096,106.6533)">
+				
+					<path id="path3088_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-58.546-48.095c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799
+					c0-24.262,19.668-43.928,43.928-43.928c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669
+					c0.656-2.941,1.054-5.981,1.158-9.095l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66
+					l0.715-1.86l3.229,1.242c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665
+					c-0.748-1.979-1.618-3.899-2.604-5.749l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209
+					l-4.565,0.718l-0.311-1.969l3.411-0.534c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119
+					c-1.622-1.334-3.334-2.561-5.12-3.682l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908
+					l-1.251-1.55l2.694-2.175c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604
+					c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314
+					l-1.859-0.719l1.248-3.227c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398
+					c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566
+					l-1.969,0.306l-0.529-3.41c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27
+					c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609
+					l-1.553,1.247l-2.17-2.699c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277
+					c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+		</g>
+		<g id="g3096_1_">
+			<g id="g3102_1_" transform="translate(133.7676,136.4482)">
+				<path id="path3104_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-84.59-96.67h9.725v0.986
+					c0,0-0.304,1.084-1.52,0.761l-0.76,0.169v18.668l-2.584,2.41l-3.038-2.189v-19.059c0,0-1.519-0.105-1.824-0.433
+					C-84.894-95.685-84.59-96.67-84.59-96.67"/>
+			</g>
+			<g id="g3106_1_" transform="translate(136.9014,135.9277)">
+				<path id="path3108_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-85.749-95.822h6.686c0,0,0.911,0.548,0,0.602
+					C-79.975-95.165-85.749-95.822-85.749-95.822"/>
+			</g>
+			<g id="g3110_1_" transform="translate(143.8926,133.6768)">
+				<path id="path3112_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-88.333-92.151v18.619l-0.861,0.327v-18.668
+					L-88.333-92.151z"/>
+			</g>
+			<g id="g3114_1_" transform="translate(156.355,123.4932)">
+				<path id="path3116_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-92.94-75.549l-0.01,0.01
+					c-0.512-0.498-1.208-0.805-1.977-0.805c-1.568,0-2.841,1.272-2.841,2.839c0,0.771,0.308,1.466,0.804,1.979l-0.004,0.004
+					c0.019,0.016,0.035,0.03,0.055,0.047c0.096,0.093,0.198,0.177,0.306,0.257c1.804,1.601,2.943,3.932,2.943,6.533
+					c0,4.829-3.916,8.744-8.745,8.744s-8.744-3.915-8.744-8.744c0-2.559,1.105-4.857,2.859-6.455
+					c0.763-0.509,1.267-1.376,1.267-2.366c0-1.567-1.271-2.839-2.84-2.839c-0.775,0-1.478,0.311-1.99,0.815l-0.02-0.021
+					c-3.029,2.645-4.948,6.529-4.948,10.865c0,7.963,6.455,14.415,14.415,14.415c7.961,0,14.417-6.452,14.417-14.415
+					C-87.992-69.02-89.911-72.906-92.94-75.549"/>
+			</g>
+		</g>
+		<g id="g3118_1_" transform="translate(0,376.07634)">
+			<g>
+				<defs>
+					<path id="SVGID_7_" d="M10.102-318.612c0,24.345,19.736,44.081,44.082,44.081l0,0c24.346,0,44.083-19.736,44.083-44.081l0,0
+						c0-24.347-19.736-44.083-44.083-44.083l0,0C29.838-362.695,10.102-342.96,10.102-318.612"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3120_1_" clip-path="url(#SVGID_8_)">
+					<g id="g3126_1_" transform="translate(201.0342,157.2715)">
+						<path id="path3128_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-109.454-506.695c0,0-0.747-0.257-1.357-0.654
+							c-1.307-0.851-21.334-0.217-21.334-0.217l0.667-0.552c0,0,20.472-0.285,21.284,0.129
+							C-109.384-507.577-109.454-506.695-109.454-506.695 M-143.388-500.48l-0.02,3.125c0,0-0.077-2.039-0.916-2.181
+							c-0.838-0.139-0.358-0.953-0.358-0.953L-143.388-500.48z M-109.159-508.086c-0.732-0.806-4.407-0.744-5.435-0.761
+							c-5.566-0.082-12.748,0.203-17.945,0.163c-0.21,0-0.935,0.348-0.815,0.645c-3.694-0.022-1.77,0-6.23-0.066
+							c-2.414-0.037-6.245,0.872-6.355-3.396c-0.061-2.127,1.896-4.011,4.221-6.279c-1.47-0.462-2.962,0.525-4.452,1.344
+							c-0.731,0.709-1.227,1.19-1.838,1.785c-2.278,3.288-3.179,6.6-2.667,9.929c2.038-0.378,3.535,2.415,2.094,3.72l-1.271,0.012
+							c-0.602,0.004-1.083,0.619-1.076,1.366l0.022,2.96c0.006,0.748,0.5,1.253,1.102,1.25l6.417,0.038
+							c0.603-0.003,1.083-0.618,1.074-1.369l-0.021-2.955c-0.005-0.751-0.502-1.356-1.099-1.352l-0.802,0.007
+							c-1.395-3.988,1.211-2.796,3.79-2.755c4.848,0.074,2.567,0.045,6.838,0.074c0.243,0.297,0.121,0.839,0.791,1.124
+							c0.415,0.172,22.823,0.246,23.283,0.14c0.462-0.108,0.343-0.331,0.512-0.497C-108.8-503.849-108.279-507.122-109.159-508.086"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		
+			<text transform="matrix(1 0 0 1 11.3618 81.4541)" fill="#FFFFFF" font-family="'Arial-BoldMT'" font-size="11.7746" letter-spacing="4">LEARNER</text>
+	</g>
+</switch>
+<i:pgf  id="adobe_illustrator_pgf">
+	<![CDATA[
+	eJzsffd+Irmy8PcCvAPYxgaTOpGcyc4J54QbaNuMMeAGZnfOH/fZvyqpM50Ic3fP/c09dz12t7pK
+KpUqqUoKh87riUK735QSfJIJBsLhkiyJo768ESRPgwfd7ng4kvFR5DIaZNNJBhoVDnINpeGNJA87
+/d4GeZXk4GUVv46cy9Jw1O8F9/vdL2kYDUai8OqqM+pK8LIptt+lRFcS5Z4kJ4c/36MqZgBVFkfQ
+Jpdi4f/5YGaDywfPT/C92PspDoed/8BbNsPneHhW7I977U7vvdj/eyPIpdkgL+SCfIYJCgK+3u9c
+SkNrm2Q+g42EXDKfxi/S+aQgZHj4hEvy2Vweviv3W+MvqTc6l/staTgs9bt9ebgRLP0Se8ET8R3e
+iMF7qdvt/xUsdsXWp+GTar83gqYFuSN2E8V+t31yZXh7KkltqW3bpnCQblQ7XQnI9yWOgiyLlC4c
+sFyjOO5026fjr6YEhOXzeXzMN0inrofQG+gY/o6Ps42DL3hSl0YjGDHgwNm6rBWNA4GH5H+Rx0vp
+vUMmF6j+HFXAyv3Blyh/Dimt0kAoDn8CldJBIc0k07TdlfQ16MJMEaryTBrb5DP4U/9daQmDIq3Y
+LIIACMF0noef2aygttEJLv3sSH9tBE/7PYnSpCCP6nTOBYFh6E/65nLcleTrXmdEx1k4yFOinPTb
+Uhfaa99XuyKhBfkfq/+kDa5E+V0aAaP0u+MRYeWcigGIfiz+knDuWYrgbCD1rvo3pI9sHpgmJyQ5
+GBXMV5aDcXFBLkMQZDLwXtBwsvpPChoBIRgVfhYm6hym7kzuvHd6G0rvso2a3Gnr0wk4cvQHGUAy
+Z/gvr/5HewqDHo2kntJzYKPSiYEtmORJHTBWeu1S/wspP8TVBPzQA1bp9t/pO+138gY+Hw8CjwE+
+n/oe90fSEGB1pWA+k3qXxZ9SkOVyqUK7I8HK7wxTwN2991SpJbU73a6Yqoit8UhKnY6Al6XUmdos
+kLrWvhBpE5FAS4mtjgxM8daV/k6Jehv6vUiAt1TgEvkykJLop5LhU0n7tEPBd2ibjqFNR2vTI+AD
+qT5t26dt+4a2fa1tn3ZlTJuOadOx3jSQGmtt2+L7uySn2tBBSUq1gN6p4UiSuziKodRCtks1x92u
+NEoNRBkpMPhIwRdfYq/d7AKVZLJUAVo71eoPfgGTfIxSsHTbEi7WFO2Dhi7Z64/a0luqUEmdDbvi
+8COgPRqAPP/q9MZ6I/XfX1Iv9TW2Pg5MtFP/7cvtNwlAdXoS/v4lDlvjLv6hNhDhuYL9ewzaAAbZ
+7v/VS0l/t7riF/kVuKvTErvwgfbVG6zgTm+yG+8gBbvSVx80yNtI/4tSAmRxZ4AjHw7ElpQq0Mko
+KMym/FNJ9ZFHem3oUkr6Iv8QRgYSE6DqHxQm+Ut/Th+2Oz87yCAa0TSa32u/vckindHKWO6TnpKV
+ovWb/EXABVJvHRiwwh6AOTUAPP02MgiZa32dNcWhpHWQ/AFNRx/98RBYJJAqGFi0Yvi9QDmjonWu
+QklzQJ8fGNn1QGt0QBud0UZnBnjquM9oi2va4toI5pq+auNMgbpOGb6mE/EltmTkd5D1pJnYIguC
+Lmm6ogOpj3HvXZTHX11xPIJ1COrgM9US4bvAVYVI0PRh42oISkPXFXyDiKlKr9VHfb8RbBg1rFnd
+PqZML1OmllRoXz1QoCAHVZDBK3ksXf0aSIFHNsMqyxn0Gp8CskjfY7ELf2RSnd4bLIvRL8NiQ1KQ
+BiArwcwBOuMfATbH4pqDNT8C/O3O21sKxvRFNHJqIPfb4xZIhA5AHKFsA/C5fOrsS3oXgwE2n06B
+AMD1A6ommxIH8MHfSi/yuVRZ6oKZwrGCwrSw2P4j9d6lICcw2LgLbNyo//pq9ruNFP3XNPI0JWcD
+yHsOc4OaI3A6CBDj77w7hlc1uT8eHPTe+oEItRavgPORTGfNHyDUwOhTHui/1cedkZQUO4OoKyBQ
+XrIUpC/hY/Kn+q/312XpDYwo/XP6tNL7KXX7AwNY7QksoeCtKA+8QZ93xZ4oB8lzDfJxB7TfuQg0
+0mHrz3wABQtggFrgp9o5CwKXBoZXPhCJow+wWEEEDjXY9E9zx+kzb3j1FtoYcrAoj4cfwat+v6uB
+Nb/SoCuPyVNs/+/AcU4+6J31KIEmMSkNrJjAtvzXYYHWzhjg5b8ZekkEPU6Mn07LDoHNew0TfTcN
+YxGR1xl+6fxkeHKOIrnVleq/wOz6coOG1AB53wZGJNJN723/a4C+Z7D+IQ4kAnP0USUt6xrANOoX
+o4xNJNyF79Qf5Okb9KNGv0APBVJHPbC9yB/BDaBGrw/0S52KX1IwHkjVO+DYSepbJngWYAxeDBu8
+EwOqE8UE737BH4fwyw949FeQZYInwcdnJtiGx3eXpOEdWCdUNm4GgqCU3uBfSw8e4ak47o6ep+0G
+YEhm0wwH3UlmsvlMjie/MBzHoSPEsBnVA7sr+O8169BrQksgvk5Jz+k4F8GkB88EsZ43fffW6pqT
+Ud/9JzDhsp+3AudFrRsqtmnY4RjAGWdgYpSkwSx8xzL0FV1VCOb/KY8BkOWhA3Clr2p0oCyOxEC4
+kVL/BsbAvzrE2hblX+TvNCdwuWDqAF5HAEIQ1nGzL8rtYAtjA0Eu2OyOYTHG/TQFE9xnSzQEe7Qt
+E0wVQQDRhgNY+XJw2Pkad8mc0SacARRMZg+8FlnqtX4BmE47iCEu2o51REnfZ9JpPu3cLdbYLeTq
+1KUkds/7QGJ4YLIdMMzQAMXZlSYGwbLBtkrwzrCPQR+goURiaj67oZPcs6lGcjbN0P7ShicSCPtL
+EX3gzn8IKYN6yIZ+YeUEbQzgmn7SJnxGhTkQ2woiQekO9EAha1adn/agk7TQQwT9oE0OfTQc9Ef0
+0Sb2NVgYj/paV5Vxp+5Ojk/7bcmWZeGzv7/ACW5LCbAA5E4TfCoFCTgmskhb/W4QC4BvaNX6AF9P
+liwMr77FH6NfA4U4kdXesPFTlIeboADqI3QEzU1/ihoDkedDh3Y9UB7aTCgN4//11AH9LPkgTLff
++sTF400ZteWCGHPWcTU7RIawPsYGzFGXRqdkEN7jM7Ze0PTPSQnWlRK+xt8RQej6YXzPWf1vWugb
+P30vdWz6D3M0Dq81Ho76X/+sJPt9fLgxFNEuR0sMlphfdvzt6wL68i/qyv+FVTp8++tfrI3/4WUw
+7HZa/+2yGDfAGYFX7WGnof7yM7m//mnJq23re4zmb1+s+o+PhueSDCd4DeavTnv04WdASsN/dlB5
+Icnr7pfTmD4k3BfzMyi15T87Ks0JdBpQsz8Cc+BYehvRnX0/Q5v85l+g+onMq/fHcksiGTULEX//
+3Y7Z+WmNE2i+jg9V+aYl9/jhAWPrf5bFGZu3xnGNSP6MmltyUPYzuslv/uvddMZLEhgDfb5oZGr/
+j/OA++Bwg1ruii1/AQhj63/5wHr9E9yVK9Ggq/fQzO3/5YMDIUPyTHwKJKXtP+xkL1fJ//mQuF9T
+zdyXZd7+YX3rrVz+11xbs7T+p3vTH4w6X8oewL+lT+At/9Nd+JJGYlscifP2Iz9nP5bVzSI/a87Q
+mHxMUo4Z/D+aa0x+NQCq39RIhnKx//fdvdk8wccFWRILZD+LvsuxeUxhzuYF/Mdj9wvtbUzvka76
+A9LKDN+x+U1n2Gl2up3Rr/pIHOmilzo61s+q3X5fPnt7G0oK/LRjU+IADMQWQFaa5hzbXqIzVPl7
+JHl1G/OllQAAY9pgOxuPBuORxxabw7bgZ6/f+uzD1+80KwmbZrMsEl2ZAh+0vxF7neEHTLOB+MrX
+OWGqCSwS/8kAhueymawDQQjlavo+aYRlcknGhfH2DY6nSmVCDm1bmiRKB4/F3vtYfJeC5/2BShRS
+t6B9o35AKxvq+mahwdi1qFZMqKEbprhtApPZgiWldlLf8dDc0oOh+oGyw6+3Ufte7gwHXfHXiSh/
+qkTns2TmyD8WopOke6NbSqsEyGo1tL2Uulf9S9qOTlZ/2MGBkLesMi2kqIAWGPj9lNMGqCyEwqVF
+rKkDJkScYNt69TZY+XvQl0fBq36wVK8rJLf6EZa/9Z14BLB/dXIcVHVP8Kp8iwEWe76YbE4qNE7E
+wdWEh2XXuo4JzfKw8jUY/SpJ3a5igQjen+z3YRn3eyOxazar3Pp03G+Jtqt98pNaHzMFMccJvmh2
+rYxni6XX6o7bklpx4GPwJM3G6Ab7GPeNhJlb6qi9JtYyRpJ+RAcVvO1gvrp1t3+yHazCv20JZmx0
+IrY0rTfxVtEftphK/cGvYFFsfaJs7bVtESmEDd6dnNvCuB5KdIqD9XHzrd9tS7Lqt+FTo/mkADQ3
+Dpoki2ECyuNBF2g9koJYukSHVJQ+xJ8dzfux0Dtv+r4OLQGr/jHJmeshdwTrNmkw7t8EcUkFGeUj
+v5joVzz9KjPVR4KysoSpvkrP9FVW+Yqb6quc8hUz1VesncTw+oibaVgZy6pw4Qh7hjLkZZHvMUzp
+jO6JYRz66fkdP+N3gp2c8/jMnoU9UbEzdjFty/xOnxmX5qZ3a0tD0kSZZd1981Q3IMI0Zb1p28Se
+PeyA6uKwMJwQrTaaXm9CKy2DBkOfzWSzWY5Ne39ldaDsm9J+Yaaw3VgNDc3D1poZjVDDe0+r9lbf
+I3JyHYjr4ury2BvYusV40GtLf1c78tDDSbF+UpdafXV+hHQuK7j10GDLuzhM6CwY/SXesSVaXQZd
+lHZrV4KpGal2sSNExTIzGoycw4h0IzHyeCK1O+Mvg0/2POkC2DkiSiUoqHEsypZGBm1uTMe0dYwu
+pbbHVGGroub+syYHkeCTf0rBK+nvUbDS7oxEo6Vj9CaZ4JvWTfAksZAwOIKvJsEaWw5UBP2fkjzA
+3OFJc830QavbGQRbfcxh+TuIRZX93qT0se3McCT3P9UAYIRRFlOQsV9VWNprCFJEaHW8odFn4aA6
+7nbVqVLK6OGt0n/G4FoauyMT/zzxE6YABFFThOXYkuxFnzlKWZe6++II8B1g8P2gPDT4Rw4t0Rvo
+IrMY2xobXGHCC2L1drPJ0tS4ybOlzlHZPHEwczybmSIEgIvRuLxzmaz/aATh6bnDESgaVa9VEV3O
+4gj5BXCBLz7SJ3QqdKTT9uGPqcJgOhxzHAxFhUsoTJvadC6fY10a6jMrOIpSbFcFZ66ABeZejUmH
+La1dpZWzCssJvH9e02FZmY0JJtJqcM3lewlLAn5KhN/tuM1ZgRDUptAgl+FYJ62I1DQqRY/YpBGs
+1RdF6XnVD6ohFlUiALxWX25L7Uk5FEyd9kem1w6KzKDBuGDhwE1rmSKXoGYq5/XgMcpoLEDDWk6i
+btxilwTDmSLZr2zVDAVLRlxS9MWlUV/odqLS9MyqgowFDBRjDet1UTFjJ2lFg6WT3sShyFyoY8ZL
+m3sjzuoWLO0rDQSnbqiiKRoVDWtpOjHyCTKqpK4blagHn6hYUvruW+pHv5kcfnYGTQ==
+	]]>
+	<![CDATA[
+	6M2n1aC2NhyAJS2LvXfVgJq0lqxfqNUohq+cekHGK3a76ieWaJa1Oda6y0MJRye7t2z1u13du/DA
+bjD+ibkFT4OH/SYWJgZ1vcw4zoc965NJdeV8+4Vkml1Dq3yw19cttGCnRywwjOraWS6TnGBHqlZX
+BlL1AOgI62+GvudY339idTFigiy3k0OshEr+dJ6E1lfyC5AoWK+T9WTwVmoCvWDq2sGnSP327Pwp
+GvzJuXcIwAzkPub6ODMFaUPN3P7oQ4vcuQMevH99Jmkqug7dbiB/D5JoEzujJ5CGGIj1aCP10Bps
++6Tthwu0YbInvYv6Nh5nTxXMItG3eOwBdWHdKasky9lSF3oE7hge6WRSFbYMp/FwE099cmlLhjno
+tn550AxFVAcWqzuoN5igj778Hw9gLfDkPZrABEltZ2Z4642S7a6BsX0wGaypER7r5U45HWbGji8I
+JHLsVP/tLTkyjMOGhwYDOflhs9kyAVA2FMu6ANQpg8hlE2B7FkY+6IoDNyampBzIb/2JnQ57YT5s
+dkZfossEak3N8sJrPHjsjBfjYHiqKcpDr2HL76pMdG3jvrabHZTz7hJJEexEn/hmG6+ZM9OFJtm6
+SnhV7La+frktduRHkqznybR9w74/by8hgUDDD7GNB/H4WoNgrAyTYq+nlqD6oJNx5DxjNySYAlme
+NJ9tBSzbIltY0wSpLKh0jezQl/6gPfY9OhO/ezHByE1iEsytvjoywyEFbhodzDd6oNfkTrt1nqUR
+xnV60nDozIbDUTfZppgHg7YLPOAvqu99sQ2Cpc01qHbYEaqC3Yu5/zIyN4OH4jlRHwCiuWioSrBT
+8Jq4ayrZ5i7TpMgLQ7ww7dDy3crWaQedO1CSDtzlcVsadt57BgWTAYvYbtxIIH28bM6pEdmPNfBw
+Nu8Iz0sFogYajptD75nz3zEPzWxQjT/dvDMitIzc6rj8hu5LCCZ+RKqjXdt8oSAfuk4m6ZHJgo3A
+egcubQebv4JlGWxR2cMYAiLpkixrx1cwIlPA1omrqCVg5VTb9WmSZuOhVO63ivinP+WBUgDWPxpn
+Xb3vfj7ChSnJvYm0ACfRRdu7m7mjTlc7UsJWIxOrutUb6i6rrf6cEKqTrch0q0H1oYtwoQ3HvZY6
+rY7LkS4Qo25N5wX3xgaDxezCF9TWBidelZH1m1rlqym1aXxm0sFP69s/552/pe65JL9JrZGZrAAE
+D6Gtg3ig24QWn30ilt1TLVNjnIjGElwCReZAHYkV+IrTqX0sX5UtHYOHeLzGEfCeZejw5k7tpJFW
+ytF9k3DO398mECJR9C03Xn9xLkutznAylgivcBD0TCy7d/SUXPpG0OGRzCYdk2VeHNKwJmblo//X
+fqctTeIlB1CRnRvMiZpgkrr4UzqBZdkZdKWCOYDlGbw1nAgdXKxJhCxyXq42rmRxMHBzU9WGZTxU
+tKfssnQ7qrftIb/Ur5WjlH6d+hV86oc0U7bU77UNFsJs3x60YZ123jo+ozpmKLiRR86oRn9w6lEY
+iGf49uoDXJ4gHr44+pCCivQODtUsjL8+pF5wSJM3xJ7xdPAgdiIoDvGxcppduaplCCdJzsWIADcD
++9UfB2GJ9IL9XlBCogBkRE3BvYudHsYLDYjiQUCmfdoDXRcc9RFESwp2SHBRDHbFX5iNjIdcduhK
+Cg7HrQ/s3kGvTGw2HQzF1gMhBfoz2H/T0XeGwXHvE48qS/qmaUvuDNx1ttpYmTiSuze0sLDbdw6T
+7/dzkotSIgbzNFjrIxDY2paPQ0uWjot6zYWW3G+KI3rAteuq99z79/uRaY/e1gTzv5vuA61zMoFh
+D8b8va+DrBzIRKirbPxcTRQHOsQTfKf2T++6W7qEm5dkL2oyWdTuK23TyBAwdmxMDRVUjZfYe1fo
+AlmJih3s3Q/SDKwSPcJjR0RD2ytXH8jU9NIjImVqXDSYjt6tjzUX0TYmolGZOOVVuf8Fev6vvvxp
+xDLdl9q4p/ts1o5eunu3urQhngVWLxgS6h3CD+pHV3LnC7+49XChNSRgrR+4hunVlkS6FkUPgccq
+9gf2wUdLtbsuYSIdP3V2gYhmm9Ou8Um/1299AMmlku4jH3XUTDv72ODkx2VQkPRYIKtMEWzDMEYI
++rck8bHQ7P/0ITvscOv95tIZl29rsvgLr6SYTC93am0gzsVY1NPXOM5Bw2hfOo/Oq4e2E2If1bJH
+aJ0Kr0FOT0jC6v4pqdgd9qT0xGNLD/cJIN+58JcrMS0fT0NNy6d6d13VOujmW6mJaWA+5gutD/Aq
+rz7GX82e2FGLguz2QI2CYbLQxNOIMxjeFWqdl8QBTeLsSO6ii5iNYPYTCX1liO1sgidbrlJboaT5
+huq7CZdTP3jXfA4sdpWeD4seuPouQIZgfIJubKFeOjjIpcsS2jIINbaTfs3Gdm+aKSYVO4nHdj9G
+PP7GCVsXG7z24kL7jbzY5HevRsXyW772ub98uS2W35j7He0tF9u+zHyE1gbX66E4Vy0EwqH4ya0U
+iqw8RuC3u1ooyte+kvxxPhTbqYVWhSG/ckEwC7tnrzvM/uvhLvYrF9vJrC+XJbk4rsROjm/LRweh
+uvq2/JlMDdP7+der2nbltihdBsJ7qeH71sbz+Um+/FDe/djcZXPJYvRrtV56PuiWK4+vMZFdL2R7
+6VApeqEgnXZUMJa1wdV3KP7xYz8UayVhaI32Iw6zHorsD+P4570ytO1BeMahBcJkcJvj9xuhvCzF
+Dyryk5wr7Gf6dRjVTa683B5XyrvrR+nNh6OT7lY49V2CoW30DUMrJdYvhSF3nHGaRA5mH4eEvV2Z
+bHQ8lOXN4ZX89BA/YFJCPWIcRkMqDXPV0Q330v9cZdqrLCHqmU4n+ZkZbgHk3Bh5jEwyNzxR5y1X
+E3Lfmz/gz1oXvr4vm5E+yc8nTxf2SGvZl/TGwUvSglQZi/yycnpM0NohzXSOamF7pFuhiDxkw7I9
+0nP2SVjiNtYDYbuxDtfiJwkHpOmPiLh2X7FHKtzfMVVm/cSCFLAQtEvVdmYlexk9tUPKVK9uyw5I
+M8vh83qh4IT0laktP1wDFruxLtUSe2sHzeSd7aw+/RAzCtLztTULefnNUbdNkAIvNisEKWJRZvVe
+fuYOTxFpdHJWk4/C9kkpBkiF/gQrvWxVHZGmu2dLo0DYglZDKsovq+EbB6TVVqa3luFtkQ4Lz7wF
+KcFC0e4L/cf7vj3SraXIcC27KtshlcevbDga2X18tkPKVPMVmH2HsWaWV+o38qY9UuH+mak+71/a
+jnSpOtwMf6Zu6jrSQNiAthYfnzoiXZPe984cRhpKycPB+QoiXZ8g70UV1studi90AmizA+tYj7PF
+ewXpfSJiQZqpH3/eUKSVp8+qaaQPe8zxYyWtI4WxGMa6/z3Mfi5fZGyRnqzLHUeke5+NUsEB6WMU
+OLm+IQ1tx7p0lHg6akvxkS3SemN30xHp6dP+YVFHCjxmQltibtbucvZIj5fH9fdmO2eL9OaY7Tsi
+DYSva6la12msR8zNgN9zQLobvXm5fS3YIr3dba7rSGFezGgbjcLo1gHpk8A8n11F7ZGenr3/uCtv
+rdshhXl5HiUvHMf6dR5bvXNCWmUaF99b9kjP9qLyY2FYIkgDYetYKz8SGQekuf3Q7SlzTJGKS6Oa
+edHsyuPbRwGRxixIA+Fh7mx5M/oy/moA2m3ZivR1/XJFQfqZX7domlXm5DRNkHJrO5F9M9KkPHw/
+XEakCeQxq4A4ToaeljNVQLo3nBCFT/08RbobqcQt5A0VqmdrFOnzaONQRxoIA4Gj17HN/e1DRJua
+FIXXbCJ7vPoDkFbHVqRyZzeqIN24SJpHun9dDK9uEaSBML97fXxsGuvy4zDdfDxHpMyEVDrNry7d
+jS4OACk3IZ3lQrN3HQvzW5a3ikaW5WJu7f76+OnQ9uuxGNpiDp5iI4e3azusODxftnsLM1AFazwU
+Lq6U8f0kN+43e5lsdYXFt1a2gbcfA1WV2b3tydmz5/00eWsz+/ujUY7decjaf32wGto7u61cOLwd
+bR4dHC4PLW81G+aIeT6OxdJj+6+PMo3TvZ3xmsPbo7fzjexNwvZt7vSBDWi6lItPSipmRZvLxOTb
+zOq1+FjZcXi7Fbkpbd3ukbc2FDsurt+uyJ2iw9f78UYpc/Vk//akUP2xHeWjlrcaxU4vP34MG5WY
+/dendz+++GGKc3j79d1PfEo5+7f3z+eBcOZSTDh8/bz+qHH35NvG940qD23einfc9lI8W3WimHR3
+Wh0tnUn2X78xzx9rPw6WbN+Gby/aN5HQ6a49xWR5u3HB711EIvg+ObGmt7niwdlF8QvfTgghudD4
+Goae18q2b8evG6DF1sNboVeH99vR9b3bdVF/uzOIbg3IbyjRBkRI7eT3V34Q6QUu3nlJc810x/tC
+1/smH3r9aJMNxcuXt6H4zUsdncurUOQxOsbfzsHF/CyFEkcNsIXuPrP0s53t/if0pr5H8OmYUye5
+3hpa49t3Y+LugHB929KQLqc6280oWHhLFXB3Uma5KS9xa9vnCcXZWekbVfDOMo/i//CLOjvNlctP
+o94naBWkQvTJGelS9SXhiJSpFjNnFqTEGidowTDu8ZsNB6T3Ly5Ia6G0M9JaTb436H3eNNbc/vJ3
+ZvykIq11jUi3Qs9GpEJ9xUjei71LA9L26irYYzra2Gb3+tQBafoDuW1gj1S4v3dGulR9Z0yrEtEa
+CQy+gwNS8CbBd2g6IRUtSANhE4GZDUekxCJxRIr2yLUTeePES3Ic68GqZVbZONgaBD35TZmI03Hb
+vV0grLQ8W5b8QFw62w75aCePG59hXVoonGyKEBmXLnwdj8SK/eEp5X74rYT23wEhjEpZbcXXzi6B
+xidx5ccuQ8M3yuwrESIhfmlcT+erIB7XHktKH8TLIgkn7Qwi7SurYAL0xdSHVA7jj2UNgeqLKQjU
+tQj9eSyz68UfVWzEUxB6sGlnpxI2/ADJWNKMfEuM7gK7+U2akDiMMmC9y8xhOhwmP5AZTI6GMvAz
+bQTl2E6T3zcQ0ED32vU5/LkaJvplvO7dqaHaxL5Lqc7yRpz8oPQ0xzw175US/XjsTXTy49Lok9uM
+b5c9OtbHh2OZHKHyQ7wr6zNoN3/87s3Vidf8xU/6gbAyQuIRWUKfdHyb6+7E8jF/wMl0Bmv13nTE
+cmaG2o2V2dUIiSu72xGLeVv7vnPnLJ2vCCc7c1afFVfW9n1Q3p3uRI5tpuamvEqs5tCO7nRePIll
+ET338Z5V9FSeSgMjAm30CD4QnmI2Xips5XlY00Dw9gSsHa0qRpntqqw8nY0c+0M6grI9jj8ejUHX
+CdpV0IM+Mq1Ko+C2XZVRx6HxK5tHxz6GFghbBmca2tOy69AIoVfpGnLqCCOJjWslBjupjvRRRVfJ
+qOyZ/T4+MKsJ2wEFbGfLNKBy0sTn2jI08TkjnSdXzba6YZoIlqfv+QnzthF5cNLSYA==
+	]]>
+	<![CDATA[
+	82tso+vpmAuwUvLREZgjKE0jW9Zdk+tb1524dOxjzLarzmjzQ3/EqtbIYS7jlTj9ocwVa7ctd4Fa
+ekmfThOPWSYUfyhSkASxbXhDXDphHXkj9dGPbZMuBcKmnm18O/SM++aKD/lD+0HGixEbKyxmpphl
+Sj5zA8uUwNfXsquO8xA9Bi1WQ8JUHRSTvc3owIvtmlmqcgbvddr5/cyN/VpPmnVht2dMidUMuRML
+x5dy7xLO/md+ybFTen8cTTpTlz6WnXXlnr5qvZVHzWLSTRgWjfGaq81vmkEvk87//MkBXVnNDwwW
+gFixAxUITw/My++YBKVJSxtgZp6fj2Jedt0UwMySdk6KmSXa1BRTIlsKo3HFu/uE2XHdx6VS8Wsd
+67ZxIDzR29GOh+QwGLT2q+B93zINNnJMN7DtbYV9qyc+x6p83+eex8WjKRxloW8/k6PdcCA8N3V8
+uH0BT+rUzr/8hhEcxrIzRDvZQSz4n6ZJF8/SkYCfrnhJAc+O2NiWM9HEcdlr82LxDZt81FZFFe8a
+wnSeId3S1GzLgSnBaYNskV8aE4oi5dF0CMxBDYMNc4Aubm0K8eGwQMANs2p4o8fno1PGLk0hAIxZ
+N5NL7sfBYgQASphIZXUeohvGt7txcWI3PrDHpiR6eeRlKVh4Fiz5wGQSHXLt8/CDXdD4dmr3A9W2
+9BfrdPLJfxwwb+zSvSMzBMJTEct9idsRi0Ax774pxErPQSzzAt8ekQVu0pW77OHYh9ftHV06tCxw
+xwiJWywB7OQV995Y7HctR3GS0fiVDQwUeDnFPkKyh0gxswU/09Ai7kML+AhwHE6o5WnDG2Ttfx0y
+0vDzds4BHY4dY3QBo8RzjfvwK/lvwQcH2pHFoF+QMA15mhiIU7wGaGOO1zhxskEUmCINZlMaU5MZ
+syl9ZDWltQiJlzE9MQcbF8tT0c5gwZ4Z++O8J2VvCTvQbnBE1CDVlW7BTW9LGIa2gPVyZNWBU/M5
+UmzjImRWf76j0QY+370O844DCoTdOd3EO/fOMXZ3AaDz2ODIqu9mEABAFrtgIckcdlJ1DrYsUic7
+lR5CT1y1ZidVXTQSM+dvwKju6nbrzn3VOUUVQAjPuD9hGJUkNhKWXVEvfeeo7RBYyt968Y63IjBm
+fplcAorujeeMxZNZm1B5tnt83nDMjqRnb+z2xAmcmVegCYriS2r22KxwfOk9zFTx0HwEmHmHcCol
+KsQvTdm2uM1rdSnx2dw7DJqEQWAmv2tmdUP6at708bPH50jKK5+kVGIXlxb/3EairdtItGu/Ei3g
+maEBa2NuiQYUA7PSQwz5l2jDT9tNHxK1nnIHCYFx81tKWKtVX5p37V/rEm2utX/tV6KpPOYCZ36J
+dr2YvVfSm4bj1tke8tjoOqVw0WRka3LCNhlHD1rfOrTYKMbYhaLglK6sgQO8s25J6nJPfJgq5+ru
+xhopm2FLHqZTF7JUV86+kYvAvIVswKeYvR/4zX6wEzPq2n9bm9lpNM1aOeZPwnjCSUzfG5OuVOHM
+nQJBoBhEsNvOuycc55VjMcnVOj7HZQjApoz62ehCLdL7Go3baMPb6e17p31kkGPz2/fgYTlnLQTC
+02lDAObsPjrqQvsYLAJbwPIRl6SV+bXYrd+QlocWu53evreDQmZ/fm14664LDblw3nBctKG7LpyU
+MOLSCTe9NnTUhZgSHqcZEQZtOJH7MkU6knn0d7ouVNe+U/KUnobhKISgXy+O7iglZWByQTpELNBZ
+8LAoHdf2RJwfgflakD4sXQCV9ooquMpaM8V6YfeZDPgMq+Jc+lrntrunusfXkN1C1y7pdA5dMi5S
+Q9zSz/KycdKSNmrp3qKWfMSTHZ205tBFLZky1/z4+/fWXPqpF5cx2sMV7z7dfSO/2bYI6nvFeV6m
+2r1BYCMPJvYdIbn3FU922hkwc3JzSNJvfQJzMDFKyZRd8q2GxcgTKcdOGbrkEhaeWFx0XqwxIH1Z
+4G80KdwGn7FaLnK5ksWTWepYGXccSuQSDb2CDk+hWUQNnXsFnVYxNGcNnXsFnWHvda4auphrBZ1W
+LThnDZ2G1LaCTs8cnq+Gzr2CTq8WnK+GzhEpqaBzrBacsobOvYLOWC04Tw2dewWdpYZ35ho69wo6
+osUWUEMXc62gI1gWUENnI6IMFXQkS226GjpzQrJzHdDA4onbu71Gu865AmvPPfeMdsk70nu+Knsl
+bm83I+7GOckieCx75bn4DTGdr9pmhM4S6QU6nU+TS+68x3e+5pxL7pdOtK5sospmMtNs3UcxGMYy
+Y+5dstnjcwEWn3F8lpoR78o5/+NLeq0X30S3VPA4dclP5aNHGMylS6qsUe3kqYvm/Mua+7hsyRye
+pYDKRyoI0WI+kkFeKvPszZkzuu8TS/MPzcZ0t8m68Sx2mz4VZMLfnzFiPDFXpkCVs5fkWew2RSqI
+k7QEwrjs607lhgAo4DF/FVr2wMwpWOCz1mJmE6JKfHLXykefMktcunNPcVg2VAu6u71VS5Gp9/Zz
+1FEmi1X3EsZpAmdVfS/bNtJrCpM4BM7MgcPYZJikXdMrBVRpOXttjXNhv7EqzV8d2OPI3ZyYpo7P
+/egC33l27ZrF8rKr4zvp60Er59K0ndHuoUOXJkxp9xx46JRzDrw2dd7zR+v4Vrx0ru86vp5thrih
+5t1vWKrmXRNjBUX8F0dgHqcg+O4X2bPwKJKZZpDm7Y85KeZRMTMdxZy3QmagmP1hCD6BmQO/WXki
+0YlUPy3CgXjfdy9dChgXuyMIr7JFLwCG6KgTiCuW/vCQzqNd57VtyoP1dvYmQrsuzp7DGRFc8X5p
+dXoQpj40kl7eqz7TDjTZGXoVyjnMkG7Bvu9bd0ac3TDnWjvvte9NDuctRndiaFFrzyo5i3pzslz2
+7Va5NXd02a8dyT0Pm0mzHXngWBWr1VhZ7EgnTn4e9qYJWyiu0mR1rU2BnKvUca6IsmYQzWyPQZf8
+lLQGfK3451HE73K1zUNSeQw6tbYYOll3cZAFzH6lbxbwqoyzdMmxHhnL2aaKyLh0iZ9Oi7lV2LlF
+ZNQzu/x1yqMozrFLk2d37LKHQ0tEhl/JDzx8OveIjMZj7NHcYYtDx4iMQcL4dBu+DqePyDj4+zC0
+tfmHpkVk7LI7/Jeh+Y3IuJynhGVo0yUI28/VREXqDBEZrEDzjMgE/BDGK9PeszhHsWGQOpnpykRd
+siT2xhZjWamx8sqm8WMsD44WUZO4e826T6Kzb2DNuTqaJ6hjGZqeOeuU0+tnaNtRv/zpqF8GR75S
+FzzLx0jqgne1oFddnZ/UqYB3Xd3cuesDrHx0Cbv5ShAxFNc5hUDNnOwvVQ8wL69Z9lHhWcQ5I0vL
+7PKx+TB7PZzp9AatIm7R9XDznT/mtx7Og8cWVA9HYhfzFYH7qIfznaE6Vz2cbicbK+LmHNVEPZzH
+iaALqodzzoZaZD2c4SYj2yK2xdTDER6bqIhbdD2c7bwsvB7O1Rdz2NbBSMp0G3SO9WJVdwbynRNJ
+jhj2Y1v6yYmcyJKYbe1fz1Ner2dC3vTnNycolMnM4Kl3eBGOxXn27o3NKWcEzrw19hSKugj1+hfD
+Js1UGc/XrmFvSw68r4xnm608LGFzL8ShFak+liFMxFwVUTRuWVrcQcAI6sa6cjzlmOMyrDzd+y4n
+dbTGgd7znnJBdPhCTgMmcDzPlvH0XgmcqZehnRZDOPMvQ4TioAsdT9NyTLNGYOYjgb1OQ9v4djmt
+EccXs8Sw8JmnKT3pUNtWpN4uoiL16XuBFakAbHEVqU/fC6lIZZfS88aPSH1W3A7KtBWpAGcGuWlb
+L+ZRzu+zN4w/X8wTjp9joM15fY71W7BAXA5N9ZdkZMy6QQERn1iGGxGPifCbbWsshps3o8e2FM6g
+xfxk9JgH6bsUzuss6MWUwmmrUi2Gmy1u6VEKN6tfOV0pnOMZRAsthfM4vWFBpXD0vD4P09CXYVhK
+utVWm4SB94nwWFdnSpDwcyK8sz12v7AD1QjFFhVAxuo1h2MMp7dhmkPzIcN+NhecqtFLyZSvLRyX
+1AWs8lNidPZ1rz6Kmy1dcucILQvaPXdAiQBd0FvjbNnZdC169u3xLVt+qN7U91Kj4nEgXJFfthvb
+V+VPtlRMHd6Wl6XDenk3Vr/a7r/GMvBb7RxarpWqd0/VNre2s1SmyoiEew3x5JvJArDc6a56zpXS
+FXOx2/LN/bkxfGUqAdvZKD3eOxW73blU2OHdfKxx/JZiN2b9xAFpZhkv1X52ui7Oo8JuwDsjxWu1
+HZHipdrvllosw318UZdit/M0Z0BqrjsjV01rSK3XxeH1mF2nCjsh6lJht1QVk45ImerR1rkFqfE+
+vrBwWn51KnZruBW7rWSckdYulh9c7uMLn3VORCekly7kPT26sSA1Vtgxlcp11TyrK+TAAu03pRJv
+vL6d8tWOLzGmnF6nlszr+kbBB8TYRn9U0VUnjPle0A1RLYtA3cKxUaglt5x7z5RbqwULZE1HzXtE
+Za9j//3pa7L2t21Ty5yjJs73WDkcJe6Uc+Vc2lPyyCe12/yyifXNeZOcqUvKPXKT94pOG12y3iRn
+N3W+onATh55NWw2pRXrPV/uMxzni5rw+l6vMJpKnPaNw01wi5zg+z3vfvC4b8TU+P3cN+C1B7fu4
+Z8Qv0b1Spn2vl77Xefl26a5uF9ApHt8Cq+nmj8P4qaaz8wPsonDzVdOZhqbU0nmdDzN9NZ1dTFC5
+Y8iJyjNU01mlE9bSLaTy0XMbO7DwajqnqPViq+nsEkmmOCHEZzWdq1+5sGo6u30a273Xuarp7Grp
+HHdGZq6ms4uzmM+3XEQ1nWPNyEKr6XydczV3NZ3W2FBLZ7crOl81nZ0yCoQXXU1n1yV9t3pR1XR2
+tXQTN+bMXU1nN3/KellgNZ0dKLrDu8hqOjtzcKJmZO5quhkpNmU1nTvFFlVN56vKZu5qOv81VvNU
+09lZnpba6gVU09kJHPO9CYuoprPbLUEeW2w1nRGAWkvn7L3OWk1nN89OOyOzV9PpM6RvrTjrl1mr
+6eyI4XBb1hzVdHa1dI6VXDNX09kNSLfGnYxS7NS8DiDZGSnL1ot3n4fvHiaGe4GYVh4WsnhJMxc+
++ZAWRutiMffVuVsXi7qvzu62Ohvrwh+dPG+2NTIpiSg63gvnZVj4Y4HyCLF43ERrWjmuV9U5dsku
+096lU761j7lL1uyOAx8WgN8u6R6mPwnjQifJz+qdqOQye0Q2e89fh2aVYJN9NBEEs/UrrRfdzVSz
+Zrzmzj4fxq9J7veau4CPiPHh3Nfc0ZvyPC7u8ldI55Ig4Tc/eb5r7vQqTpeL7ua+5m66iOKs19zZ
+RRQnLrqbrlapNHnNnfUkcNuL7qbfPOJ3r2OGu9hnPOdqcLSwOovdjQtfxa/elUWBMAxuIzJ33Zl7
+LkbAF4fuXoedU2p851ofLeIYfryeziH315yp4l1h6JzE4bcqDQkzT/GrucjQaEA7cw==
+	]]>
+	<![CDATA[
+	svMNW8YNEJCRk/VE8Mys6LzOhnLa78FytaTvmXTOhqovLhuqvshsqLrPbCiPxObzL1+JUN6Vj9G5
+t0IIFMtx4Daz7xPONCrPIbOLwJltBVqgGCrsZq1lNwBzPlvQxw3s1sJamwOK4dm2u5b2fyogAiu5
+F684ZwRMZHQDMM5XZrhBdzmS8oe0Tkg51X2vLkYEWmtRawY1PIt57Vf6C/1h9ZOn6e6jMuWmP5Ul
+YWdHGGvfFnaD4U3fUsgw29offvq6aMi78nFzfV4/oKSfUjzXbjWB46ee06uC23JE8Yy9IbGLTXNh
+xZQX8VgWiF0hw8w7vGh7rU8UMqx9e1am+FyGM9xwZ1dfee+2RT7TDXeLuLfa+4Y7X9b43Dfc6ZWP
+9nfcTbd8nM4rnuGmvIXUJZnvuJtjVNa6pOmupZvhhruAz0NyZrvhzu+p5pikMj8ByR3csyRs2BJQ
+XGrY1sIazh70X1grLjWXp3JCHSofF1BY+/StV7fPfs4VheMvmuWac4Vw5i2sJVDwrJv5C2uxN87n
+wp1dGOxkH2VMtz7q2+2KmAw2jGUZJmyW4d2McS3be9+cD5aZtoipIRNfy0mLOZQxOZHyzt1tp+f1
++XXc72Z0221X5Z2vMLWfIqaGTHz3RfiVWOjp7sCb/UqnMqa17RtnwezDMDRFFbBTPgvb/BmGpWSC
+GIZmLKWk553fvgzDe4thaLkpb9oa1+Ldh+MZJwZRYD4H3qUizMMtct+xsVLMV7G4j6OpAFTGYsPM
+XuNqPQvZITjp827B2a971PJgySV5i6pxvbercHWqenaz0fTVy6SqjYQdPrXMTCrJ8i4La58W6V3t
+Zu/LD9X7q/JDRd4r7GeuDkvFZKtUKqaOMI2zPlAVT7hrppgSXbLcw3Y96D4a68TNF4U9Ol/+lrvY
+ODeykqkeLrbZOnMqwkt/BMLr4a1Q36kMz7b2Ty1Na6cckTLVq+KFyX+x3MNmrBKzIn11u+YukTcg
+NZemBcLycCM21NBaS9OEu4/jTYd72JYijqVp8viVNRThKXelGQi8tfl16YA0s0xu13Oqh3t0RBoI
+A4G/nAsOmWr/6soR6eqx9NF2QirpSKmuNJfhXdw5I62cPtYcyWu6vNCIFOYF0F5MzCosTQU9+U3h
+8w2f7TYt7RTJP9FSeDr2BVGIntN2ipo8ztgYnadatWB13LVGVdzixHt22s4xbZLELWOT58udr/b9
+5o+56ebHsvWsTu+UIeeSpG/3LgX8d2qqVBjzRpdB8pfnTq3Su2RJrHKKwfqIJJ2vhfxOHZ0XZzpN
+lVrlXpU2VWqVS1WaY4am+XRTX/zUny5LyzG3pzxNyqZXlyy+2Byljl5ZWvQsAl+lgM4H3ky5Xlzy
+tPZobyb9HLNrnexPCCty89ciXImXivv2pa8Y7NynxhkoVlnYvvVLZQG7PDC0p/njYy+VBZzbCHOu
+r96Zz7WeKrKM0VHnKsC5D6HFGkC/9WKeXgsCc87S8hMfsySNNLm+9QZKcenYfcx+JUyTGy/KR3YM
+B08dDK5aJKg162a6w67wEDLnw670AI1aYecdVaEnQ5gSCGrepy5Qe8TgiTtXt7koR3+FZNpO4mdu
+tJhzDibOH5uvxsrLeDNEY+kJVE6dkhzPOfBhjZvvF7PI+6lLAfX5M8t72/p936WAnne5TM6fQ2XK
+2vZNYmHMcJP0vmXGPzDnnfVAeGpgnpf/TkMxz/t9/PeLWyTF+EVSTHAENlEubN7hnbUK0K91aLwr
+bfoqQL81gJOnajiBmOdGPbPVN20VoN8aQCr5Z60C9PahHO5HnqoK0F7UTdYAuuXBOs3Q9DfqWXMV
+pqsC9FsD6FJj5UiO6W/Us/WRfVcB+q0BdPKRlf5MjMpiPfm8lG/GG9mmvJTP6basxV7K5x5VWNSl
+fAH/QmOOS/lMq/K3XcpHoqOz3oDn+1I+Oi9uN+At4lI+sPnxWr4F0ckp+WL6+ytnuZTPLqqAnToW
+npxs52s/Z0OZb/XTbzGb714/rXrP9la/qSu5FnY21Cz3+jkNbW3+bNvDRZwNNc29fq5Vd1Y7ecZy
+xAWcDeXrXj8f9ZULuNdPo45tYdMEJ894r5/7rX6BsA+TXaWOy71+U1VyzXyvn5kjrLf6WTJVZr7X
+z31obvdXTnOvn2NHFnEDiHavn/uAAj7KEedKgCbT5HGq+RTliG4XYQXCvnPOXO/1c1+9ijU+971+
+7orO7CXNfq+fYa5sbvWb+QQqy71+zmxBLViP5Cmf9/p5ZUEv5l6/xdS8e93r5w7Fch/fzPf6maC4
+5VzNda+fYzoZ2QNxrUid4l4/9w0V9aa8iTrcKe/1cytPqffQ5l9QlZjLrX6WuteZ7/Vz36chVQML
+uNfPxXO6T0ScKlKnvdfPtrpAu9VPk5Zz1D1oRz572Jbz3+vne+3Pda+fXo5otzs80318U5/i4XQf
+3/x1D8Zb/eap5jDe62fj5Rq2iP1k2/q51889sdUcg539Xj/38zy0e3nmvNdPLbmyz88wVAzNda+f
+pxxbyL1+TnNKb/VbyH18nkka/u7jm+MwHT2jewH3+sVcb/Wb6vSGyXv9vK/ic5Qws9zr51JswS7F
+0K9cxL1+NuxluNVvvqo0v2aOHoeZ714/dzNHr6yf714/jdq2hRoz3MdnWz09bd3rbPf62UDxeTf6
+NPf6uUNxzrmyuddv5mJ4WpM4/71+7rf6IZZF3Ou343qrH5FjC7jXzz3RCWd/Eff6ubvtlGLz3+un
+9cvfqpzxXr9Z/crp7vVzkIHKrX6LyR4kXXK51c982vzs9/q5G4aB8GLu9XMviLXTyLPc6+dESnqr
+n6s9NsW9fu75wFpEcc57/aa3YWa5189pJumtfj6raz3v9fORb7mAe/3clYMWgdfVw7GQnLDRjgWX
+LlO9MJnxoQd2qQ2zxq/kP1OW0K7rHqZH4r25bNEix4T4pTmGtWpa9pEvYw4xEczahSCkTEAtgcoZ
+g93WDCKsCAtFHqPjUCK1dpLkj/MravPjoSxzw0Jo/V2+SCXCG6v87Um6kM7Ehh8Hqf5YXNuXcvn1
+3ceVh6XQwSgaKlQvU0v3L5mNlfpNvxAIhz979eM16WOQyNSPvxvZz/bx+97n6+nHkVTP50+f9r9v
+6uzg6K3+cdHpXtdSJ+ObRi0aaTRKseiP+/SPs6/z2ObbIPawN5LD9ciaLPMroaW+1E+FmZWPzejD
+cesGKJaPnUR2vle+jpl2uFeW5d2N89D6c+0kxBXPurHNlrDHVJndHaZ6dVtlasv9U6Z2dvohy53d
+hDz+2FkbrsVPmzjwkFJpufNdiW3nTh9xSkKk6A0oVrnJNuTh++EykzqTbAWSMi+kvnRnOCo/VAvH
+1e3Cdku/ApLeI7hW/L60EIuQKhBek7qsUP+4XvmW93qZ09Dt6VFMH6t1pOPX5Mr6avjufCW32S2G
+z+u1w7XX+sG2kF89ycS04lCYpqdKInu8+gPYIlYlNYkHiZDceU5hAeclqJYz2WxslYzL5zXcNTIa
+MSeUeGtRH5qufTS9Tytts2sbq31OqNwWv2/2UqP1ciwvNFPFCre/B89ODvferq9OC/uZ19NYPr29
+W82vXLZLz4fL+2SkXPE+VqHLmhzqtlO7jeD+SiRWjofHgXA1sn9wwFZeNrZKHTHF4uT0Kq3P7zyT
+uvtMcI39dpxJid8J1PErmBGRwK9BYW73P/nd66Uk2axRJfvyGnGFmFRaiJI/gWJ7fVwv6Y0YeQDL
++fIb/txL0D+fh1Kc/MavbG29VhvRxyPm7WXvfW/zOCRDv49oR2k340zvVXuxbnxRCjcDYe1V3Pjq
+mm1rL5LGF+/bb9oLxvAisXLwob44jZKRsrXjJZE8I7ryNGZoXntJtrTmCeOLwQaDz1KKSkifMliw
+9MXuZ445/JOjsJsvYVEFcBEjTQJhtjlg8ZyOi4QmfFaAWSJ4P8xFksJpZUoI54Ihh8azrf0z8qcC
+tvXwyBI3hUndV2Opk/onD2+v4uQtF81stHWKXSUpFia6kmO4bj1cieejL3ubzM2KcWmCyKQClXiY
+k96rIvkBXkqHB7O/CIiMoYdsanm4FbvelDM718JpIfvcjlC/sshFH+ohhX/vH7nCV/94WDi6vX3V
+2YuLjtuf6sBvDazClfe30RK8pdzNlR8OWMr25dZZmvwWCHPl7jWnPB0/vpDFzlWiYkP5jXtPI4g0
+BdF42EOID0lSo8I1uuC6k28b40sF9mv0TuO2B864KrnXzfYP7ZUQq9zc7eNYmoaxvN6GSihXNvGw
+4stiN/m+XjhvvR2Xjw5CdT1Uw6gHOpa0GN2qKQKviuMiHx4fSCrS5xRd56vctUB6y69uPqaV38pi
+R2vHK+1uvgqW3gTChbPS1XO13F1qFS6vntYqzcTerW4hUFVuNr+h3+clTftuWLSvVfeuP1eBYqH4
+x4+7UPzmpRKKn9zehaKnDxHUyIeh2Bj0Gdi5+6F4dPcqFO10d0KJ3sVTKNZK5k36GuwDEk8lvlZq
++z5CRgoirEBE5rqWBZ2uD5RGIBnhz3vwb86FCJMaRXC6G6NqhTvJwW/7a5gT+o3HSmLweT9KFi4G
+C8mf8OO+n1Tk4l7omcwp+pWlZJyU0HDP462DVOdulKTz1olvxIilxK9sVg7tPEywdE+P6LLXfuCL
+ayX7fCcbJYsC5gVY6ZldL2RBXO9sx9QuH1EBgXITx3IELJC92S+9fhbaXPHheldREzvHDJNuHiF7
+HbFGoVf8zsDkvJ+hgCMUU0aIlfVPBcVUq5Xi9Jm4dDCAPw9oEzCM738Uu0u9KrufqLIIwgh7f/eS
+t7PvDPv7qwarcCf9NNRt1Mng5dcjFwU7gmt88YexXS7OsTX2sco232P3RPmTL9j1YrusRHss4R8W
++HWXe10/2uAi75frduYpw0SSm5ote2qK3BDrcJRBTs0jL+7hjyJyMlc9pQ+iW6cbyNMHyMmXodjF
+0iq+rYcSBX4Hf7SB2e/2Q1FZjofiodc1VNo3VnaWzrdjyM5hesBB5amK51xBy6y2Vvcq4mvlc6/3
+nXrdu1m7vC9cbf6IlA8eM4eF+jiytLe1W01qBtg3AUuu9k59hPtxs8NlQEpulDaitSAtdaqrMuC7
++97r78v31UZ8f7lw9r51XLgqCyvlt4vhJTGChqHntbJinG4/LAOCkx7K5F1rdofzgM2YL8pvq4Pl
+Db5UbsLAWw0fww2E1QH3ZIBYF6yOHS4aELPcGj0oQjkU4qSHFxAnDLqLGZZ7xbPzPRCJ6fSrBTNo
+ZBdSE8xP+Vkxc63G+t7m00cjEC4nL1/l0tt2rzkV0fmCHCo7Tvdv4rGd68Z6xeIq0AwhsBliyk3f
+yjEb4ALGtBNn+GKOz2WWN44v9zYqUqf4GYlcVPbPO+zedyFVKB98dYagltiishaFcgekyeUIV+Va
+UtgvfOnzbIpaT01vv9TGnRHFA8NjQvJLsZ3xashx6DMOHGbf19DnYzS0LacYunXguw==
+	]]>
+	<![CDATA[
+	mzurRimPetbSG80TtxekBjG6vra8FYp/D45RjB6jLXAELxIyCs86WAV7IGnXi/FQIpd4MdsHDDbe
+hbVPzATDkUWLWOwWjleicAsTMzfS3s3R9kG1MboKVV4zZx9kBtAe817s88o2sGC9Bzy3bFMlv+uA
+7YZLYhwwp7mxYkK+DyfKgjTMpE58QZMMwuxmpWy31ibrkn6HmAmE5xbrPnS4Px4za/HpMQfCv8Vo
+8dJi8xgtjoQmZ3R7DXia4dowWnHNGhufa5Id1xWRlqaVNSeP2VprqMVmkSvoFtx861kuFreAfFYq
+Jhmuclu8PwVOjg+YvULr4rRa3o2lDwvx/sZa+aE6eiYRt723q8FmRX5unqW7zZeV8lg8P9tLyaOV
+4uspV6/ml9M7ejxuc/y+Ey8mBfmGW9tdr+nRQbqbEFHPH0ut4IqnMR41PvgKrllmeViJdR4+Clc3
+t/KmlJc/YfShj+z3/uVxRRTXkpWH9tIHobthBsL95xLaBxzIseI9e2AaNT2RzxvzygpYEt9POAdA
+/tLLk6MdRU45082J4aly6tgMSG+5cjK5dQvy/Jnd2zz8vPRrwxCkZiNiJusJbJiZDUf/qozkXPnS
+3f6sJ3tqB8Lz0NvvmGfXYtMo0UDYUY0u0FwCG2Yh9oM7ZoyOTqHAbTF7y9dFeeK4HXFucM1wh0Gn
++0xe0pR2W/bcaCdjBx4XqFWcPfH9nY3S46G60LYvrUQn0d/iXXvssqm1+57deD4/yYPqyOBBqVvF
+QBgUxfIpebC1lRhtgQapHYPqqR/vpUa7R4X99HUS1M1NHf5kqhur/fJGebmdYX6LfplRACjiFufl
+N7irPvTLvI7yoFQqfq71nsrJ7NqQKFbQ+z5V6/+ufplFswXCPgbsOFyQMIMVH8EYWvu2oEkmQj3R
+S+S6lrgA6pfZlfrm0Ur5qVyrbX+CXOG/HQcOWJyMqNlNqInFBf7LVHM+G4sHwrOHwfxj1k5p9re8
+ZlxcgfCipYmDHJvLcPQ3XIXH/C6vGccMEmaa5TXjwBUe87u8fCwu3LG6N6Y82WbdxMuXHIb0TkOx
+h8heKNYVqqF4o32If67hhuAzxvBOcd9kE4N7Z6Ho61tO2SRstPlQ4jB/bwn9BcKW4N+soT9Xqw70
+y4Kj7XYGHcz+guMUfiIkM2yu6LzvKGR/q4+sWdHAyQuOU9gNXNlL+g1OjNGHQh6bKRQ5ewx26h0P
+Z3t6hvjYLJE5E+ZZ42NTcTx6r+6uxG+Mwbr7b3p8jGYazRQf6w3k6tWucEdckmp+aZydylexW+Vo
+W1rX+Vqk1Ak9Rv0ucare6D0FncwtzRVS3TW96tnnQmPXpFHpI/ss+ZRt3wQK/gaW0u3j1WqdJrbQ
+lPGpFf3u5fpT4er6x4tPL4n8RlMxN+M0QkSCoPQs7Cm5rVBtfHbXq4Wu+MMlQqKvMfIbSZwchraf
+1Vxd8Tvl14rG/ZffOvFk2slpJ79z4sm0o4T5rRNPJpvoyt858b52eeaeeDLtxHv9nRPvb49v3okn
+006yoX7nxJNp19b+75p4LwvWfeIV0360G/ORLa2dbKwl5tONG2UEURMrsQPj1H7m17U0a3RnjtPW
+7EH1z4gSUdQTEImWi23XK23VMG6ZSgeIJt06utU1KVe6agp6N8kzvPPmRAXwGjZXoyOIcfP822CF
+rj5wh4YRkGeh7fsvzT+9Nt3gQub83hgMXk33q6YYLHnKHzzqIOrmy11omqqSBFhtrHHRr2IWc8Aj
+bO3lnUE+iCrPxO915dkn1vDiGZVpLSW1PeEg0fz6DTampdGv792ui4QtMPEe0ybP+zSfP7L72DUs
+CpKrSm8yIpcKaTfTPBvW9Gb3+hQ7uoQv7s1X20T0ebkL9VMVen+RXLx/1FblR6S5cvnEiktCDdaL
++Woj9R4HQrFxSK9sCAnDx1V1XUXxUqj8st4bI/ORA+kpCfZ4JUJCiRDeCr2qRBBSOhGwP5/WA9Sp
+9CoP6xoJnowkGD+eaSSgV1QZcuHiPojA711EIoQI8ljcPTORYGOoKhGKNKTf8oT6xZsI9LxCwv3F
+6JHGB/vPyaUf1z74AHwxED6MwsTZs0+FCNyYNRKhdXbixAfKQVK039z7hR0jAcXcQWjc6AjCHQBq
+kqgS7ZkVROVpZ10nv+N6wHlxAiEu1WLz9EFnSFyVs4Eo3t0nfAyDACBabBIEORl3jmHQ+jONpci+
+2JRMNT1XkowIo3wy8uUUq9sAwMCVKgBKMd8gCF/OJWEiRr40gvA7GxEjV5oA0Iw7u15YQeh86Twb
+uxufPRXAumEuaEQxYuTLWZgq4s6V6tp3BaHzpQsp3VSeUVoy++V6U7vormduGdWZj1xPqLV7trbz
+x2Muo4oaeWwKyhp4LOrEY375PKrzmIVBzDzmNgyjMp6WQSiPRY08NtMwdB6z43M/PBZ14jHfffCl
+kUNr5acLBQQ3fDGDWPch+VAju/RiXefLGftg1sizUGLdyJVuHOGskdcd+dKH4CIAZtfIxOWSfkgp
+xTUzlkgb91ei64Xn0NrgqhGKbp00AuFQ9FWKmSumJkqyjM4JOqGKI8nRwqf2amqVVp8qhVQnPaWQ
+6kxaVyvs1rbrhE+iNOyoVAxtr7P72VCFrX2sH2ouZVwvXAPY1bGh8gbe5hwqb/R7edRAwQot19Nr
+ZRXH/GqNe61cnOLq5ZQSxfTTkG2+XMewtCdFS/iiu3ubmrdcTI/OV6Ta80PzRyBc7OaWc0iEZWRE
+EXedrkJxMZ00UEy7Q9NStWU5qIZJ3d+xapHWLQO9uVglhXKGnKtJIqSTa7p7jF5+lxRH2jjFxriz
+6qdfa7TbpGv/LHMhrewoxHrg9/UQRfZU3N1W4jnGc9oOmbeN9z02/j6s4j0cWeYtUi1y0YMVVi3S
+qg9wQSYN94rSoDqJWKg+OYkA3RBSJiZflDlSYJw6qX/zjNTc3iHiFhipkWRbK181rfyRnFeyhLsJ
+TSHLHJ5XdxRGbD4n2Nr1V1nJ4zENbfP5q3GoF2qjGGUoCdZ2j3dIPRwlvrG47LgeCLOxz2qZi14W
+N5T6PDpgS+fTCaUClnRkeSuc+uiHs1w0IaT5wnr+FAcUZZvH10jFAYvzckfuAAOVQE4C37nvjZEH
+eX73OinEdj6/R8oBtxNLII0jZZijsrKG6KkL5DhwNSSwRWdN+qzmuQp/ewy0q3FY+9bc3uOi2ZUa
+lsqxOLQiv7q1n+NXef4w1YkfVLG89TmG5Y+kuI6RRns7/OrrqfJFjb2rsPHrLw6/KKY6OwdVLCfd
+YOOsuAdrO3+GmZDkkOU0G9EqKKNmmsSxeDKV6qT3drhGq5pk42sfUUPRHx2GEvcZ2L3QTpsnhSXb
+94JxGa5yMVr0uV5iN5VSx2qjoRa6nvfVfgHXxt/fd8h0KlXWn0tJWhq7kv8aAcU0AYGH1UWU335I
+68qoMExiKAQlf25EkLv3E8qfx4IC4O16Y6RUNacPGK2q+ZmcDjTKqzWZSm2nUtmpj2BnO2Z4Ia6U
+ttUXpYT+wlTeeZAyYuFXNt8L6qszVnv1oqx4kM76MyPmWilueGHAjCWfsCrXYaU+kZMBoiSm9GMM
+ry5Z8gDYOQR/nu/psBvkeDR4ViX1o6iHpSJZchi8zJHDOshxDNDkLIVyJQ4Ivlfgz2tWqeEl0wMP
+HnmtJj6GPLaM72OAIPkFsvZYJ8yrioUs14dEOSVurW6899auq1sV4YfuGSpRxNrdhfmsG/XAG03q
+5qGPvdJUEO3g6fcmHOdNeyTRw9xFPler7q1JV+WD9nZoUoNccYbC92i3sawWzYuCNnCRMFcgrExZ
+84yc2RBXwoXN65TC+M07BuTTQRR+e2QVfd584XbyBxzMVVPk1d/aAgGgTOznJYGXIOfRoKX0eZdS
+vv58ZNTfXnRua+oCF160ecOLlxDfUCriT77Dylg+vzIGKS69RN9gLB+Z6pmilr1VsC62KQFHd0kN
+aUthldELA7JtD6u/RZb8hmMZtfXDB1rKoRejH4KlP6WP9Oimuh7d2czeJJZOqq8nYV03Z93r0kFa
+apXpv68uHe0xtTL999WlI8Us0us31KUT60KpTP9NdemF/9kJZHO5TDCXzuWCqctxV5LP5M57pxeM
+BzYDqcIBy1732v2qLElX0t+jcr81/pJ6o+BGMFWolw4Ocumy1Oq3pWCc7nzpTBBX+qhwLe9kg1Mr
+tPyWr33uL19ui+U35n5nwrTn97dJUTlY9WAxbNHiyfhH5wNzpJJ4aEIdyyPLoQRzwhGmczyyh25R
+PWS+HrYSr9V+9pZn2vpbpe5Mlne2m4X44PRw7yg/3Mntb90mq/0H4aYiPz0w5Yfq/RU564dM/OTJ
+hcf5mU6BiCTEJRzfIf7YxIr5cxj16ovNKRCTVeSjvRyJWusKzHRmjrjy9URFztr2PT0UAw/2IgyU
+0J0F/FM7AQbXnfJbhEodafhJDIJ1ReWzSxi434+r2Qiw5JDd95Pahylt1+UJFtWgqDK+ENGXD9OO
+RDbUFxvrhnVlOOlnZw+wGNS/QbjuVJOGF8/jlz19eekvjOhrG1Hqsxkw1/ZihrMmXoy4a1Vdv74A
+Aa9BY9eOVfFfO2NQd8cUVV275oiUM9o656UYUe+KoDg/SGj3L+ChcHSpnB8nqQ2wtn03hD8vGQyj
+sPCjjX/eUbCwXnpJxZNbSUbVM3MOyEzGjNbM/VlSwWIU4d4KxSoPDT7dZcoOnuY5zgDxmjGsyuvt
+jVLhenXztfSRPRoUrgq9W2ouFB/XXzB/gxyI07rTjnK54jX2ejXOb/M4brALqOZrXiapQVB5Kkfp
+b+LSDTUSNC8ez/pGf4rs+xK9QX5Tprb5nqY2ALUjP6+TGBdhYdZyZPcmoem4hNF6/BQ5g/JH8a9Z
+KZ/vgqoyHtKGM3N2r6v701pceEww/TFpcW0ZuXH0mCLHYkG/C+v0t8rTYYz+Zuj36J0nz9RIg7E3
+mYev/W75LTy8IrUnd0Lh6I5ZNkpdh/PsdL/S8bQTmu2VCZfGIGmlu/Jye1wBij3XLu82ns/6EXKQ
+WDHalc/3UqPMfrHCJK82H457O7Xuzd1TYT8TauopCVrWxpriKilzFVVF1HlfWcd3nzF6yhBKxpch
+dZE6S+erdPbBQRqqXk2Sbg8p9n1aoLFjcnwY8e3xsJUdIhl18Qdf3DBEONLT0ffw9qckmTI8leuB
+Skv7s873GctxSOqLowgxjaxnjdEcITxobKB0GcQnCWUpxh14TJrhYTpmbFBiyodbfWbSczIHt+j4
+TmNK9JuEFHAYaMidJpRjyAYbuGd8qhs/kiLMwGnSYRMD2/1EOuPttGroyHxO8cTZUacGdbtSeUlr
+SQUXpsgkPfUwQfIS1Cz31VbuaCK1YRQZaiDOJ1Mb1mskJVVNoOivT2ZgJOh9Dko+LRfJ3/OmHIzM
+cihcXCm7JHEUUyf6Pjlbvaux+tl8ipRD04fmBqc6O9cVwt9o8O6QFaE+u/lWn93LqQ==
+	]]>
+	<![CDATA[
+	zlkvph/SRUxf08qx31Ynm+p0h8Utt4AoAppbsM05pFcQE9l+W90Y/Z5tWz3qN72C3IqCuQXW9AoM
+RSpEeDESgQSxlcyCByMJoDem3J7cQE+vUE6AmS69QtuO8Rt8t+7hJjQiKEgJEZQpmcgxmSTB9sgu
+wwQsWL85Jrsb56MZ0yuU+0owLLU2V6YOuI8RRwDEP/UGMfyMztMHPC1t7Xt9nhVBbiVw7wPJEXIb
+Bj1RfQ5Sgp2fUM//mXUY5Nhezz4Ewi4grjdS8+Ts4NGdDAGAcmwmEBjQjViSpxzXtpJVZVndqLuj
+fkHYA8iP1ueTMGgpxGz74MQRgfAEJY5jcU8Qxj5MALhmE5bpVHSlcTbErVMdBP/YZXNGEC9ZP0xl
+6QPJc9ZAvG+n5lkbxISyo0Mg7FvpJVYOWJqculTbL6ogMsvrjzL/bWhXK35HlXbVH6xOscxyWDgt
+vxpbHi+te/KY26hq1xGD1DHxmF/CgHVozyBOTBoIW9m09i5YWWS65QomqZVB1FxHv8PYX9lLTb9c
+TTy2n6gycw1jP3PMOvCY3xW/v3vJefRB3kmxGoB9YZS83jJqZDwK2Jup3PrQfI/FHPugamSnXigg
+Bux0TGXpA2BprWQTc634VmI76U5K1MiugquVKc0kdYiTnWYjpAhRWZWWYgU29pldQ8fgRXUQT3r6
+FpUeP4ntnHdphEQNB5KAPEaX1IC8eis9OsCK0wy4iculRLbSWZo0o4Sk09v0uGywYB9l+LOUVD+r
+prTovvE0a1CnDf3k6qOo8VV+pB08fWQ80hoUj3ak9ZHxSGvQBtrhwEcps5f7bsBiibxjhPPUeF43
+yL6mdma28bRuEEfaad2nSeLsoHigpybjKkeGPGWV6CiNvO+kL4ywYQkgbS+U/QLgxQ3FbYif9KlX
+DeyFHHGRUs7R3j1Asl2wyhcX1wQo0fvavuB+Q1ZCGdGEgGxzlTDuoBlTQPyewxyevAlRc8e56H51
+a0aIdvACYS56cbw9maaSey/UxyudykP7HGMpV6zOv8bA7/0Lr20dCsYzs3ezGqvcJpR54coXJRQQ
+tymV8TFhpfmMnuMtq4aJbkleQh9/47XfBAqgsvmFJ/A/JJRztFtk4h9S2j3L6QdGhfNg4DbulXvR
+YpkPvPFF+XNF3Rf8kdZChBnHg88VmWx/ULn+w3pQ+bMh+MOvRs+QqM/w4/4WwwjPrPab6axvfvXk
+XcCngk1/LqqvN/elciwXrVYrJzc5fVb1/W8lY4lS5PBLEQrVRlTdKxSXDkmMNqY2uvlG3kniMLA/
+6k6FFl1TDowGcURDceuF7YFJHNUFJTlhI/JNKEvk2F6C1BGhN/IAS+5GVvf7skriGfgYj7Y3n4Hv
+8GQlL75AEZbSZZe6/wLSK0YFl9rlZ0VG7pQSNDL3PGx+0m07k+Bi9K1DyxYGTvYJ2Xsl9YA5ekY7
+iquctnWoyBWQVElFSBFJBDaMEuarnTE0f8GQNEG3MM5LMHXD/9kJbAbCuBPYqPTaxl3AQDgMT+rS
+aDzABulGUXrv9I7FX5IcYIP0fwz8D39m80GWywW5dBr+SOPT42YgMvz5zjOMEA0e9wLhRqogj8qd
+1qjT74nyr+AGPGKDqWK/3w1GCgf16m2w8vegL4+CBEXwqh8s1etR3HpspO5Ojk9xHxI/SlmAuL7c
+DEb+/ur24HVCHI3kTnM8koYK0IIsixOtWh+dbluWerQNF0wd9Eb6W/wx+jWQ6NvIx2g02EilBmO5
+m+zL76l2KyV1JSTeMMUm2VQ0mKoD0t67GcJPsTtWQeDz4Ua75dC0J34pLZU+0raeRPlfGXdLlsRR
+56fU6n999XtDQoLecNn3qFtTjLr1rxn1X3/9lfyLJ4PlGFhhwOW+R+zc1mbIpPG/bsxsPp9PMVyK
+4xJy+y0x/NUbiX8nppl2+Mw/EUjjfw8ROr3PYUscSJTXobvDgdiShin1uW8ieHxgQwn9i38HOYb9
+dmcA/yWH/bHckt6AIlKyJ41S5auy9jLBJNujtv/1oXw2xSLRvviHqUKEYV9O+hMHarc32v0WHZX3
+gCe/+YeHzCSFXJINyvlshvExZpWBN35K8hA66WfMk9/E5x8W6zos74HUb2qNq4/OsEJ1vZ9xTHwS
+9zB/bjrDTrMrTZhB1wfl4EZQN6028WuWaYBxBa8UfPBfgAkW4L+7vwLjwDf8p/4cB67tbTEDcAAt
+5BpswxU6Nf4Awy/44xB++QGP/gqyTPAk+PjMBNuI/TJAmrQDmWAkGry71brBBsvw6izAJNNcOpPL
+B5kkk2fZXI5CTQosPM3AL1khzeThaTLP5QWWC96JCm6O4uaZfBIhBPlsLpnjoelXgE8LyXQuHeRz
++WQ6m2eDxwFeyCezWUEICgybZLIZDp9xgD2TFkg7TsjjozSbzOahFwKbTeaBr8mnTDLDprmgwKWT
+bIYl4FgOfs3nyac5Pk2gwRdpgQ0KfAZ6xJJnrJDM5JgseZZlMuRTJpNMp/lskM9zSZ7jeHjG5REb
+i+1ySYbLkWe5dDIjgGEt8HySYbP0W6QMk4Fv2SSfzyAOLssn2byQI91L57M4Mi4D33IZGAXiF1iC
+Ip2ED3jocTbJ8tksacYm89BRgYHRKM0ygCGfBgy5XDKfzZNRIMlyeSQx0FMgT7gkjBBaZbNAOY5T
+xsXloJs4ESyfyZJn2WQWJxXbCRxLSDwxYceBN3uWzCrrFBdP/QOkwNUvX+rvnxSJ08jBVr/Xk1qg
+NBKtsfxTHI1lX3rA/fv/Q/LRIJIG4uiDZ9IZd6nkINoiwL/k/1DKWH7RXrFCNgkMzgPLw8qL4me5
+LMMynKH7hXa/KZ01fwDRT0R49rfSTyv/WfGPZLE37Ioj6SmioBHigAThP0UN8Ek7MKS+THQpaFOI
+cE2v9Adm8Z0WphLfJhHtSz+kOS8EIDQFXUxbcDBE/Bv6oMkdTQLqYtwgFDXJrssdXWLZPDN8+hG4
+DfQCF74Gx3gObmqCCR6sOxNMz1meAab3xBphol5ledA+qM0yTFbAedOeZXKgYAWYLi6Pugx+gVdE
++wKRoXlGf9AChcdi67z+jMtw8Es6qwPSn6jo4Dv1mcBmEEtQA4RaFzSRjk170ApoXdIbqd1W4UyO
+rRTYBy469cdFgjcXJbPp+ZYhP52ZNj0Cbjp2mHYZqzNtXMY2z2ZbxuxiltwUwp2J89kM9p4Xfo9c
+Z71XPBW79lM+Vmxu7CCQnwGDLZ8BU5BRrO50TgCTFX7BghFOmDC2uTTYfWAagvbkMmSpp8FKZMEk
+1p7h5IKtm+NhQYFlKoAJSp6p7TKw2vI8PlOAGR/AKs2DkYgfskze0EiH/sdU/GMq+jEVMx7Sdx5T
+MQ0mHDh+DLiEGV4xFUE68fnFmooKmjgiQfi/SaakPXRI3iA8qD9Pd33wf3cF8OR/IGWyDPiPf/0b
+JMTwj4T4IyH8SAgPXfpHQqgSIuNpBJqsTBIIdDI95gz3UWMfrfWMkMxlWF7xN3g+rT/CmB34gkwa
+pAmQKC8IvBIUYxgub35mBffHwvgjP3zKDw+9OY/8yIJO41nw78D1yVP5kc2CehMWKz8UNHFEQuD/
+Jvnh4YhNZ2H8fgnwx4L4IwH8SICsh178IwFUCZD1jIX5sSAWuG0IXye5DNmFY0EUsOiqkGf5dJ7s
+fcHzTBCfZBmyGyYk83w6DU+y4LHkQFzk2GSGAZlTAhECzgibNTyjYoUTEH4OZE4a+oSbbdlsNkeg
+Z7LpnOFJnksKDMeTYKbyjAQhMyDxMJopCNAcA5U8jzFTJk03E7UnNJyZz2SMrUAmZsA61CFpTwz4
+9Gdqr0jUE0mr9ZwXckAXDMzqY+bTPODj88YxY1QvwzEsoVZawA/AX2PYbIZsOpKAHzxgOQ6a5Bnw
+5ICOJbLnymZwT5MHSUx3a8GnY/Mgn/m8AJ4i3fvET4VMmrZjyL6hARz8wucBCPQhn2EAdR7kP7iJ
+5EkmS6K4eTq9iJJJ8uk87gYDh6TTGWXrl8kKHNkNzbF0nxO+5RkuS3aN01me7GniyNFRFRge6Aom
+Pj4B8mErdE/zMOnQ/6yAe8FMFjdgM4gTcyXyeYSfQ1hkzxSepXNAMYFFjlbGxNKNV4HJg0JKc8oz
+DiNzAssmcwJOF44AtZXA8slsRqDhaz6Le77QCRZohyiBehgHZ5FhGIoRCYqb2Sz0LM8JSi84XCTk
+GZfNK+qTzfDYszywH7TjhTT0C2nBwXzlWOQLdXebA4rxJD6Om+Us3SyHKWTzhLIgW3KMgO2EJJPL
+Ufh8kmORqzlkGqqxcWwsPoJ1yOZxSDhI4AiByyZBOAFKPgeg4BeBy9NNZkDJC0lYaWnSKgOcRlAC
+VciHeaAriR3wfBbYGT/lMUbKEZ7i0/CpgM+Q6LCkyIccjhJ+4Rgen8ArPoPxa2AGYClECZhyZMZ5
+ThsR9BromSNf5niO5gTAqkwjFQFRmuFpO+ADjqYEpHkORonDJZPLo2zBcQNNuCxLQ+ZEipRIskIm
+kyWQoNtkRDg1LN3VyOXSZNyE6oxAlIaSbwAfsgLZ/AARn0brh4UesEBzAenLoe0DIgLWMEeeZDOw
+3kokxQHYlSPdAqYgvAnsJxCvlkfGVZ4RBgT4MH9KnAbbZWER4qM06jDc9M9QlPAGeQ1TAwSMMeMT
+stwAJawfJp+mKHMglki6AC6uPEUJ/xKGgnZsllW+xeVA26GBSB5xDKwQXNqCgoBK0jxAgObkCZ9j
+UBJg5gXHorxF9siQABKmSvAwOvIMFkuGPMvgDhKFxuD84TMQc2yeEC0DiDgUq1nc6cBFwOB2VR43
+MAgNYaqwDWDEpJQ8mUkQVWyOaAsQjxk6lYCaIbKBQyXE0nFnQYiSRyjbUfTwmGuCO10C5oNQggEf
+Qh9yoNBRaJNtLYaoJ3gkYOYHMjnpH0KCjmV5yvhpWM3KszR0gHYsS5iHywJyYEXK1HmQmFwW2DxH
+1BHIOBbYictCn0FLUfgg4hAnboPwZAECb6apSswKaMTz5FlayApK8grJmSELJUuboUIGuAKHPJZF
+BNBZnqNigChaLgPcTR7AskpnMwQj9J5lVfGkJLPkMA0GJQNDE1e4TFZtBeNhiHjiML4Itg8VWbks
+7jICAQSkGIdkyuMTDLAg/8LayeSB40rkO3AwcjTLRmApRlQYSC9YFUQ2UlMgg7oJFXGWJUkwqObJ
+jiJ+C4IEpjIDTIQ8R5cdPEjnkd9ZIvMZnggBBAXdEYheAd7mFVCcQHSUMg6MieIeGnYXdE2OZDFx
+6RyqhzRplmeEHDFlcgysFIGBPmAXMJyUzuSpBsQ3JbIFR5J0UHuC9BAU6GkOVSssKC6tRGZR+mV4
+olHJkqfPgBXzpJ2QRcLCE9QTQA1cgEJQMbkEoui5tIKQEwSa4gRrT0XIIauh1cCmeRW42YD7E7n5
+47f589tyvzHyC4IClF0GbDoWFhrx20D2gppZrN+moIkjEoDP/x63Lefh4E65NfTH5Q==
+	]]>
+	<![CDATA[
+	+uNy/XG5/rhcf1yuPy7XH5frj8v1x+X6r3e5/myV/XG5fLlcv3Gz/P+Wy+WZtOy9U+Yrszs7XXb0
+mDh56u5bPs+jwIRf0JvGDTcmnc8zWTI7PE4Fgx5NhrQBIY42EBbbCeBE2ZTwgRwm2gBMcrAEOdzR
+h1+Jv6Q9OzY8A9MGNCmvPAPHJEPELljuaPegycHlyJN8FkyJmwA+Y1XZzNDiP+URkW+0HA5tnDRq
+UHSdQAXT2jdQ7sS/Am3JZg1PNPC0LC9PDCvoGJPDJEZtSPAEWnKkE2D6Zfm03v3Jgd8Hqn8E6h+B
+6i1Qwdb9jaVw6JFlsuk8D79miEDFCAy4lguuhaN4QKSC5Ywhnt8iUsFYn71IRklbNEe2JuQXh6In
+R5YxWFUovpg8yczUHlFJxSkhBoHUJKlNUBzkOUVMgaWeUyQEhqmsoP8IiD8CwqeA+I0WF67XPMOi
+k8LyaSogwB7IMgvOTlLwCCAg0gTBbxIQ09lcMwgIjIPlM4rNAPbSl/4MDRA+nabGBlY6YKQ7z2il
+cuozYuDkqdEzAe/P3tcfseBPLLC/MWeRFTBixVG7gadiAdR7buFigeJBu4EnCH6PWGCnS1q0iAX2
+NzlLrKCd2ZFOZ6ivBI8YjJ3hMyFNQt7wjM9jtJEEaTE3GsNj+ez/b+/8WuO4oSj+CfY77ItfgpPo
+74xEn1qTQCHQQltDHo29uIFgFzv0z7fv/Z2rmd3EbYmp982Pe6zRSBqNdHTPmessJFfkKuJeSSLK
+QC4VRrYmlcNS1kxigtQe5vYZMgKAl5sVU9BK0WYxllqFBFoF0tD4CE7ZAV0xdjAiYcLGkmdYD5MH
+uyqBXyEpjbAWobE4Is0CWlQoW0G7FoVJHAJRHF4IcghIkjDVbKSLB92zxxSJkCGLMHSxxxEgQxvY
+A5HPz4r6u2BtetX8Mnt4s7LJ2LAWYnV2niyFTCcLculn3Sgxc2CEuWepHktNe2R/vwNMUTuC6C2o
+s0R2WzOk25xJVX2Lrn9x4kzVB3eq1U+cLXHEpXSi9IIcPsw9Nh65Kq8t7qeFUta0ng8nj0f2Szks
+NY3gr6bhVlloeh/TF/njzDPTzP1gShPnt9GpCH2dcze6cOfpxlkdDmnqh8jBMC1YQ1RqPlClTZ6C
+Js1TOXgsC3KpSaBj+r5U7K6HrDXtkcNpsGKjVTmOTwu85WnaPnhjz545/PNm/XWb9THz3SAM1NKN
+RsY0NuvSc3ryhDe6Tz21m6j+I+3Vx0540x8bLvU8Zy+OFzU1EhRkZEBXK7aF8h1UepVzlsIvNRSB
+37V1Q1hPz2UXkO6ZkFzZAVIYXgorM2MCeL/JyeZJJaeKlUpuBkFYRoJyBZBdRXfrnnksUue5WhUr
+/IHKbGnfPmwnMQyiH7KWyACRYxtBE8n0kbaOkw7cobujxv0tduRJEaEbj421+lzHIWwnIE3augGN
+rqnyYvd+/w835MwESaOB7mWo2FfaGMepkEAtTYM9ZTtpTbP3tTc+QUcQLuope1qTRScniW26jD5n
+RgbLB4VmGZ1sx7AN0IXUll2EN8wdIgsGEqbgjSoNMmFInLs/kdiDX8cfq9eeInTIOufq9FJKJA+H
+g8rUKQ/Spc1XWIcWwC4kChttbBAkstQhuiIJKwJ15pnrrIuyc8zYExSwcnOCDdiUnRsaHRuKNgry
+mQfDShlGil4Ong8+koCNy6rOcB9EbynQbk2YMk/aKm8z9ihMCFmyuo1zh20GmyoJxpGj8aEsc1PA
+BybDShtZ6oKR2rLMZrGogNIJhbWJ3txGEzhUTJKkE6ordzMKPfw4PDor0avkYWNY1f0+BOhkyAEb
+Fhexpj7KoS1wu9qhT/Z8qohsQI1mnFCoZ7dIgWn+59UNBaQ3GpY6qcdpvCQJuqffoicODFMHc70O
+jHfW36RZyY0gXsEpdPILs5cWEvtoQJ/GTPHoA+9WHbkPg5tO9CYFccjuoQk6nMIsIHTp7wDJySiW
+NoacUel1CW70oAULH4AejBHNQALGFDwlIhPYTxsgNfipYXJvIFhDYlemxTr8A3YYarLc2Fm07cv4
+iyajndwJM9EXXrQyORIy6Qt5GSNB2DjMO+4Eijk6Vpusfhy1/Hfg9cTjEuW40atia0qZMKpQiYaE
+VaYkr6LbxBcyjBHBk1n4dXNmPrMAs4AU6D6GMhmUcP99uVxBJ1/8yx72zCifGeVnjDIdMSqcyBNq
+NME2/VhnZ5R46kJ4WkY57pNO7S66wXEoZfofUeGvoZQxPS7NoBuY5Ly1vSBPEf/0iuG74kyKd9nI
+SpGFuFc+gGcfbTIjD2TsrZ9hODNZAXEOrleSNHfCA7rUvkeWNpxtHmLv9hh7hJ2grdKldnxzMRKd
+WdqwIgftWrF3m7VHK7b2eq394djsU/X1/34mXzW1V0T53fxr7Mk2oKed2MdOH2eD96gZ95p/C8K/
+BLGWhu3rt3e73S83V7dWXr9s9fn+5mr3p//+yVbRv5bftsZz3bc3nz5cfPxwcU83TjffbL68w7vv
+/F+LvLm5Utrrly83Jyc/Xlzvfr67+PBxd7e5vr/4fbe9uLm5/WRD9Jv9ZXt9t7u3e+2297/e/gFi
+lyzFT07e/PB28zc2HXbQ
+	]]>
+</i:pgf>
+</svg>

--- a/misc/openbadge_badges/badge-organizer.svg
+++ b/misc/openbadge_badges/badge-organizer.svg
@@ -1,0 +1,647 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 15.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [
+	<!ENTITY ns_extend "http://ns.adobe.com/Extensibility/1.0/">
+	<!ENTITY ns_ai "http://ns.adobe.com/AdobeIllustrator/10.0/">
+	<!ENTITY ns_graphs "http://ns.adobe.com/Graphs/1.0/">
+	<!ENTITY ns_vars "http://ns.adobe.com/Variables/1.0/">
+	<!ENTITY ns_imrep "http://ns.adobe.com/ImageReplacement/1.0/">
+	<!ENTITY ns_sfw "http://ns.adobe.com/SaveForWeb/1.0/">
+	<!ENTITY ns_custom "http://ns.adobe.com/GenericCustomNamespace/1.0/">
+	<!ENTITY ns_adobe_xpath "http://ns.adobe.com/XPath/1.0/">
+]>
+<svg version="1.1"
+	 id="svg3004" xmlns:x="&ns_extend;" xmlns:i="&ns_ai;" xmlns:graph="&ns_graphs;" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" sodipodi:docname="creator.svg" inkscape:version="0.48.1 r9760"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="108px" height="108px"
+	 viewBox="0 0 108 108" enable-background="new 0 0 108 108" xml:space="preserve">
+<switch>
+	<foreignObject requiredExtensions="&ns_ai;" x="0" y="0" width="1" height="1">
+		<i:pgfRef  xlink:href="#adobe_illustrator_pgf">
+		</i:pgfRef>
+	</foreignObject>
+	<g i:extraneous="self">
+		<g id="g3014_1_" transform="translate(0,376.07634)">
+			<g id="g3016_1_">
+				<defs>
+					<rect id="SVGID_1_" x="8.996" y="12.472" width="94.089" height="88.952"/>
+				</defs>
+				<clipPath id="SVGID_2_">
+					<use xlink:href="#SVGID_1_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3022_1_" clip-path="url(#SVGID_2_)">
+					<g id="g3038_1_">
+						<g id="g3040_1_" opacity="0.75">
+							<defs>
+								<path id="SVGID_3_" opacity="0.75" d="M97.635,57.893c0,24.043-19.487,43.531-43.529,43.531
+									c-24.041,0-43.53-19.488-43.53-43.531c0-24.04,19.489-43.529,43.53-43.529C78.147,14.364,97.635,33.853,97.635,57.893"/>
+							</defs>
+							<clipPath id="SVGID_4_">
+								<use xlink:href="#SVGID_3_"  overflow="visible"/>
+							</clipPath>
+							<g id="g3042_1_" clip-path="url(#SVGID_4_)">
+								<g id="g3044_1_">
+									<g id="g3048_1_">
+									</g>
+									<g id="g3046_1_">
+										<g id="g3050_1_">
+											<defs>
+												<rect id="SVGID_5_" x="8.996" y="12.472" width="94.089" height="60.786"/>
+											</defs>
+											<clipPath id="SVGID_6_">
+												<use xlink:href="#SVGID_5_"  overflow="visible"/>
+											</clipPath>
+											<g id="g3052_1_" clip-path="url(#SVGID_6_)">
+												<g id="g3054_1_" transform="translate(147.3794,85.8701)">
+													<path id="path3056_1_" inkscape:connector-curvature="0" fill="#E0DBCC" d="M-89.623-14.21l45.328-10.739
+														l-4.811-11.497l-29.209,11.827l31.233-28.749l-11.184-7.164l-28.445,35.326l15.784-46.417l-13.273-0.455l-8.127,44.384
+														l-8.562-45.706l-12.344,5.011l14.763,41.621l-27.216-34.201l-7.569,10.913l30.339,27.546l-34.05-15.046l-1.419,13.205
+														l40.594,9.439l1.426,2.298l3.771-0.895l1.432,0.715L-89.623-14.21z"/>
+												</g>
+											</g>
+										</g>
+									</g>
+								</g>
+							</g>
+						</g>
+					</g>
+				</g>
+			</g>
+		</g>
+		<g id="g3058_1_" transform="translate(57.3389,463.82834)">
+			<path id="path3060_1_" inkscape:connector-curvature="0" fill="#736657" d="M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248
+				H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3062_1_" transform="translate(57.3389,463.82834)">
+			
+				<path id="path3064_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-56.339-393.355H50.072l-2.128,6.585l2.128,7.248H-56.339l3.192-6.916L-56.339-393.355z"/>
+		</g>
+		<g id="g3066_1_" transform="translate(72.5313,439.77264)">
+			<path id="path3068_1_" inkscape:connector-curvature="0" fill="#9D8478" d="M-61.955-354.134h87.259l-2.13,6.917h-82.202
+				L-61.955-354.134z"/>
+		</g>
+		<g id="g3070_1_" transform="translate(72.5313,439.77264)">
+			
+				<path id="path3072_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+				M-61.955-354.134h87.259l-2.13,6.917h-82.202L-61.955-354.134z"/>
+		</g>
+		<g id="g3076_1_">
+			<g id="g3082_1_" transform="translate(63.3096,106.6533)">
+				<path id="path3084_1_" inkscape:connector-curvature="0" fill="#9D8478" d="M-58.546-48.095
+					c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799c0-24.262,19.668-43.928,43.928-43.928
+					c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669c0.656-2.941,1.054-5.981,1.158-9.095
+					l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66l0.715-1.86l3.229,1.242
+					c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665c-0.748-1.979-1.618-3.899-2.604-5.749
+					l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209l-4.565,0.718l-0.311-1.969l3.411-0.534
+					c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119c-1.622-1.334-3.334-2.561-5.12-3.682
+					l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908l-1.251-1.55l2.694-2.175
+					c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952
+					l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314l-1.859-0.719l1.248-3.227
+					c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626
+					l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566l-1.969,0.306l-0.529-3.41
+					c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053
+					l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609l-1.553,1.247l-2.17-2.699
+					c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394
+					l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+			<g id="g3086_1_" transform="translate(63.3096,106.6533)">
+				
+					<path id="path3088_1_" inkscape:connector-curvature="0" fill="none" stroke="#FFFFFF" stroke-width="1.0704" stroke-linejoin="round" stroke-miterlimit="10" d="
+					M-58.546-48.095c0.032,3.55,0.442,7.006,1.185,10.338h5.669c-0.874-3.455-1.339-7.072-1.339-10.799
+					c0-24.262,19.668-43.928,43.928-43.928c24.261,0,43.928,19.667,43.928,43.928c0,3.727-0.465,7.344-1.339,10.799h5.669
+					c0.656-2.941,1.054-5.981,1.158-9.095l-3.956-2.381l1.028-1.708l2.952,1.777c-0.024-2.13-0.186-4.228-0.472-6.286l-4.315-1.66
+					l0.715-1.86l3.229,1.242c-0.392-2.086-0.914-4.126-1.559-6.111l-4.545-0.889l0.381-1.957l3.399,0.665
+					c-0.748-1.979-1.618-3.899-2.604-5.749l-4.627-0.086l0.036-1.992l3.456,0.064c-1.078-1.814-2.269-3.554-3.561-5.209
+					l-4.565,0.718l-0.311-1.969l3.411-0.534c-1.374-1.596-2.847-3.104-4.409-4.514l-4.369,1.498l-0.646-1.885l3.266-1.119
+					c-1.622-1.334-3.334-2.561-5.12-3.682l-4.048,2.235l-0.964-1.744l3.028-1.671c-1.826-1.028-3.722-1.945-5.682-2.74l-3.604,2.908
+					l-1.251-1.55l2.694-2.175c-1.97-0.692-3.998-1.265-6.075-1.706l-3.043,3.487l-1.502-1.31l2.274-2.604
+					c-2.056-0.337-4.152-0.548-6.282-0.622l-2.387,3.952l-1.706-1.029l1.782-2.951c-2.13,0.023-4.229,0.18-6.287,0.463l-1.667,4.314
+					l-1.859-0.719l1.248-3.227c-2.087,0.389-4.128,0.908-6.114,1.55l-0.896,4.544l-1.955-0.385l0.67-3.398
+					c-1.981,0.745-3.902,1.613-5.753,2.597l-0.093,4.626l-1.992-0.04l0.07-3.458c-1.816,1.077-3.558,2.263-5.215,3.556l0.711,4.566
+					l-1.969,0.306l-0.529-3.41c-1.598,1.37-3.109,2.84-4.52,4.4l1.491,4.374l-1.885,0.644l-1.115-3.27
+					c-1.334,1.622-2.566,3.33-3.689,5.116l2.229,4.053l-1.745,0.96l-1.667-3.031c-1.032,1.824-1.951,3.719-2.748,5.678l2.903,3.609
+					l-1.553,1.247l-2.17-2.699c-0.696,1.971-1.271,3.999-1.715,6.075l3.483,3.048l-1.312,1.499l-2.601-2.277
+					c-0.339,2.053-0.552,4.15-0.631,6.28l3.949,2.394l-1.032,1.703L-58.546-48.095z"/>
+			</g>
+		</g>
+		<g id="g3096_1_">
+			<g id="g3102_1_" transform="translate(133.7676,136.4482)">
+				<path id="path3104_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-84.59-96.67h9.725v0.986
+					c0,0-0.304,1.084-1.52,0.761l-0.76,0.169v18.668l-2.584,2.41l-3.038-2.189v-19.059c0,0-1.519-0.105-1.824-0.433
+					C-84.894-95.685-84.59-96.67-84.59-96.67"/>
+			</g>
+			<g id="g3106_1_" transform="translate(136.9014,135.9277)">
+				<path id="path3108_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-85.749-95.822h6.686c0,0,0.911,0.548,0,0.602
+					C-79.975-95.165-85.749-95.822-85.749-95.822"/>
+			</g>
+			<g id="g3110_1_" transform="translate(143.8926,133.6768)">
+				<path id="path3112_1_" inkscape:connector-curvature="0" fill="#FFFFFF" d="M-88.333-92.151v18.619l-0.861,0.327v-18.668
+					L-88.333-92.151z"/>
+			</g>
+			<g id="g3114_1_" transform="translate(156.355,123.4932)">
+				<path id="path3116_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-92.94-75.549l-0.01,0.01
+					c-0.512-0.498-1.208-0.805-1.977-0.805c-1.568,0-2.841,1.272-2.841,2.839c0,0.771,0.308,1.466,0.804,1.979l-0.004,0.004
+					c0.019,0.016,0.035,0.03,0.055,0.047c0.096,0.093,0.198,0.177,0.306,0.257c1.804,1.601,2.943,3.932,2.943,6.533
+					c0,4.829-3.916,8.744-8.745,8.744s-8.744-3.915-8.744-8.744c0-2.559,1.105-4.857,2.859-6.455
+					c0.763-0.509,1.267-1.376,1.267-2.366c0-1.567-1.271-2.839-2.84-2.839c-0.775,0-1.478,0.311-1.99,0.815l-0.02-0.021
+					c-3.029,2.645-4.948,6.529-4.948,10.865c0,7.963,6.455,14.415,14.415,14.415c7.961,0,14.417-6.452,14.417-14.415
+					C-87.992-69.02-89.911-72.906-92.94-75.549"/>
+			</g>
+		</g>
+		<g id="g3118_1_" transform="translate(0,376.07634)">
+			<g>
+				<defs>
+					<path id="SVGID_7_" d="M10.102-318.612c0,24.345,19.736,44.081,44.082,44.081l0,0c24.346,0,44.083-19.736,44.083-44.081l0,0
+						c0-24.347-19.736-44.083-44.083-44.083l0,0C29.838-362.695,10.102-342.96,10.102-318.612"/>
+				</defs>
+				<clipPath id="SVGID_8_">
+					<use xlink:href="#SVGID_7_"  overflow="visible"/>
+				</clipPath>
+				<g id="g3120_1_" clip-path="url(#SVGID_8_)">
+					<g id="g3126_1_" transform="translate(201.0342,157.2715)">
+						<path id="path3128_1_" inkscape:connector-curvature="0" fill="#2B3990" d="M-109.454-506.695c0,0-0.747-0.257-1.357-0.654
+							c-1.307-0.851-21.334-0.217-21.334-0.217l0.667-0.552c0,0,20.472-0.285,21.284,0.129
+							C-109.384-507.577-109.454-506.695-109.454-506.695 M-143.388-500.48l-0.02,3.125c0,0-0.077-2.039-0.916-2.181
+							c-0.838-0.139-0.358-0.953-0.358-0.953L-143.388-500.48z M-109.159-508.086c-0.732-0.806-4.407-0.744-5.435-0.761
+							c-5.566-0.082-12.748,0.203-17.945,0.163c-0.21,0-0.935,0.348-0.815,0.645c-3.694-0.022-1.77,0-6.23-0.066
+							c-2.414-0.037-6.245,0.872-6.355-3.396c-0.061-2.127,1.896-4.011,4.221-6.279c-1.47-0.462-2.962,0.525-4.452,1.344
+							c-0.731,0.709-1.227,1.19-1.838,1.785c-2.278,3.288-3.179,6.6-2.667,9.929c2.038-0.378,3.535,2.415,2.094,3.72l-1.271,0.012
+							c-0.602,0.004-1.083,0.619-1.076,1.366l0.022,2.96c0.006,0.748,0.5,1.253,1.102,1.25l6.417,0.038
+							c0.603-0.003,1.083-0.618,1.074-1.369l-0.021-2.955c-0.005-0.751-0.502-1.356-1.099-1.352l-0.802,0.007
+							c-1.395-3.988,1.211-2.796,3.79-2.755c4.848,0.074,2.567,0.045,6.838,0.074c0.243,0.297,0.121,0.839,0.791,1.124
+							c0.415,0.172,22.823,0.246,23.283,0.14c0.462-0.108,0.343-0.331,0.512-0.497C-108.8-503.849-108.279-507.122-109.159-508.086"
+							/>
+					</g>
+				</g>
+			</g>
+		</g>
+		
+			<text transform="matrix(1 0 0 1 7.1079 81.4541)" fill="#FFFFFF" font-family="'Arial-BoldMT'" font-size="11.7746" letter-spacing="2">ORGANIZER</text>
+	</g>
+</switch>
+<i:pgf  id="adobe_illustrator_pgf">
+	<![CDATA[
+	eJzsvfd+IruyKPy9AO8AtrGNSZ3pdiY655zGxtC2GWPADcxac/64z36rpM50Isy397m/OfssT6NW
+q6RSqZKqpGTi9CJbbHZf1SyfY+KxZLKsqfVBV1uNk9L4Xrs97A80LFo+T8VZMcdApeKe/KxXvFa1
+fqvbWSWvchy8rOHXy6ea2h90O/HdbvtL7afiyyl4ddkatFV4+VpvvqvZrvZe77T+R9Vy/V/vKQM2
+NFapD6CWnGfh//m4tMoW4qdH+L7e+VXv9+ETACfxMg9lpe6w02x13kvdf1fjnMjGeUGO8xITFwR8
+vds6V/vuOjlFwkqCnFNE/EJUcoIg8fAJl+MLsgLfVbqN4ZfaGZxq3Yba75e77a7WX42Xf9c78aP6
+O7ypx+/Udrv7T7zUrjc+bZ/Uup0BVC1qrXo7W+q2m0eXtrfHqtpUm551invic63VVgGBX/VBnGUR
+18U9lnsuDVvt5vHw61UF1PKKgsX8M+nUVR96Ax3DZywuPO99QcmFOhjAiAEGztf5Tsk+ECgk/1t+
+OFffW2R6AetPKb1Zrdv7qmuffYorERDF4V/AkhgXRCYn0nqX6levDTNFsMozItZRJPxrPes1YVCk
+FlvAJqCFuKjw8LdQEIw6FsLVXy31n9X4cbejUpwUtcEFnXNBYBj6l745H7ZV7arTGtBxFvcUipSj
+blNtQ33z+1q7TnBB/sdaf2mFy7r2rg6AULrt4YAQs2xAAKQf1n+rOPcsBXDSUzuX3WvSR7bAxYUC
+0BpMFjxKPBfnJNK6JMGCEEyArPWXtoutYBtG4wWYpVOYtxOt9d7qrOpdKzzvaK2mNZcAQ6Z/SO9z
+su0/xfiPdhNGPBioHb3bQEPlIxtNMLmjC4BY7TTL3S9Eex+XEhBDB+ik3X2n78xn8gY+H/ZiDzFe
+yX8PuwO1D2211bgi5d+1+i81znJyvthsqbDwW/08kHbnPV9uqM1Wu13PV+uN4UDNHw+AkNX8iVEt
+lr8yv6jTKnXSWr7eaGlAEW9t9d983apDv6+TxhtG4yr5MpZX6aeq7VPV/LRFm2/ROi1bnZZZp0Oa
+j+W7tG6X1u3a6nbNul3alSGtOqRVh1bVWH5o1m3W399VLd+EDqpqvgH4zvcHqtbGUfTVBtJc/nXY
+bquDfK+uIQZ6H3n44qveab62AUsaWafQWjPf6PZ+A5F8DPKwbpsqrtQ87YMJLtfpDprqW75YzZ/0
+2/X+R8ws6gE7/2p1hlYl49/faif/NXQXx0bqGf92teabCk21Oio+f9X7jWEbfxgV6lCuQ/8egjCA
+QTa7/3Ty6r+Ndv2LPAJ1tRr1NnxgfvUGy7fVGe3GO7DAtvrVBQHyNrB+UUwAI271cOT9Xr2h5ot0
+Moo6sen/VPNdpJFOE7qUV7/IP4SQAcWkUeMHbZP8ssppYbP1q4UEYiLNxPmd+fSm1emMVodal/SU
+rBSz3+QXaS6Wf2vBgHXyAMj5HsDpNpFAyFxb6+y13lfNDpIfUHXw0R32gURi+aKNRKu25yKljKrZ
+uSpFzR4t37OT655ZaY9WOqGVTmztGeM+oTWuaI0rezNX9FUTZwpkdd72NZ2Ir3pDQ3oHRk+q1Rtk
+QdAlTVd0LP8x7LzXteFXuz4cwDoEWfCZb9Thu9hllXBQcf/5sg8SwxIU/DNhU9VOo4vCfjX+bBev
+Tln7kHe8zDtqUqZ9eU8bBT5oNBm/1Ibq5e+eGntgJVZfziAE+DygRf0e1tvwQ8q3Om+wLAa/bYsN
+UUEqAK8EHQfwjD9irMzimoM1PwD4zdbbWx7G9EXEcb6ndZvDBnCEFrQ4QN4GzctK/uRLfa/HY6wi
+5oEB4PqJs0ohX+/BB//qvVDkfEVtg47CsYJOtLDY/kftvKtxTmCwchvI+Pni99drt/2cp/86Ri5S
+dD4Dek9hblByxI57MaL7nbaH8GpH6w57e523bmyZKouXQPmIppPXn8DUQOfTC6yni2FroObqrV4q
+sCEQXpoapy/hY/LT+Df864r6BhqU9TktrXZ+qe1uz9asWQJLKH5T13rhTZ+26526FiflZsuHLZB+
+p3XAkdW2VRahUdAAeigFfhmdcwEIqGB7FQFQffAB6iqwwL7ZNv3p7DgtC2/vooE6hhYvacP+R/yy
+222bzTpfma3rxaQU6/93wDglH3ROOhRBo5D0Cm5IoFj+10GB2v4Q4OV/c+vlOshxovy0Gl4APN6b
+kOi7cQiLsLxW/8uiJ1vJKbLkRlu9+A1q11dQa4gN4PdNIETC3azedr96aHjGLz7qPZW0OfiokZoX
+ZoMiyhc7j81mg5nv2B8o9A0aUYPfIIdi+YMO6F7kR3wVsNHpAv7yx/UvNZ6J5S9aYNWpxlsmfhJj
+bFYMG7+txwwLionf/oYf+/DwE4r+ibNM/Cj+8MTEm1B8e04q3oJ2QnnjWiwOQukN/nX14AFK68P2
+4GncbgCEXEFkOOhOTiooksyTB4bjODSEGFYyLLDbYvResz69JrgE5FuYDJ2O0zqo9GCZINTT18i9
+ddvlZNS3/xMbsddPG7HTktkNA9o45HAIzdlnYGSUpMIkdMcy9BVdVdjM/6cXQ0OuQp/G9b4aroFK
+fVCPJZ/zxm8gDPzVItp2XftNfoucwMnx/B68XoYW4rCOX7t1rRlvoGMgzsVf20NYjJkoVUEFj1gT
+FcEOrcvE8yVgQLRiD1a+Fu+3voZtMme0CmdrCiazA1aLpnYav6GZVjOO/i1aj/UFSd9LosiL/t1i
+7d1Cqs6fq/X2aRdQDAUO3QHdDM8gONvqyCBYNt40EN7qd9HjAzhUiUMtYjcslIdWNVHOigztL614
+pAKzP6+jDdz6H4LKuOWvoV+4KcEcA5imn7QKLxlt9upNHZCgdwd6oKO1YMxPs9fKufBRB/lgTg4t
+6ve6A1q0hn2NF4eDrtlVfdz526PD425T9SRZ+OzfLzCCm2oWNACt9Qo2lQ4EDBOtTmv96SZm0L6t
+VuMDbD1NdRG88Rb/DH73dOQsL3b6z7/qWn8NBMDFAA1BZ9VfdZOASHnfp14HhIc5E3rFzP967IB8
+ViMgpt1tfOLiCceMUXNGhDnpuF5bhIewEcYGxHGhDo7JIMLHZ689o+mfEhNsICYijb9VB6YbhfBD
+Z/V/00Jf/RV5qWPV/zBF4/Aaw/6g+/Wf5WR/jg5X+3XUy1ETgyUWlRz/+LqAvvwXdeX/hVXaf/vn
+v1ga/4eXQb/davxv58W8KOU4nhcMhdhvrL+jzO7v/zTr5UQhpyhy2GD+jUSq/+nBsAyTE1iWDRvN
+P63m4CPKiPSK/9lRyYUcV5D5sEF9qLgzFmVURs3/8GQZZqDfgF67A1AIDtW3Ad3bjzK00W/+C4Q/
+4XoX3aHWUElAzX9c+oOM+k934Usd1JugDE3bD2XKfswbLpoo1GWrTD4mUT4M/h8N7yGPtoYurndI
+UFCp++/tnekPIf3F4qKm1ovEi6QvdFbBqKGCIuA/IT4npHHcVFMvuz1Sy9m+b/XrVr/12mq3Br8v
+BvWB5bWizMX9Wa3d7Wonb299VW9f9K1KFl2v3oCW9aqyb91zZEDVfwdqWLcxREkXu4zDrXUyHPSG
+gxDHlo8z7rMDdnwXvn6ne4FYtVBgEen6FETA/XW90+p/wDTbkK9/LQtjTWCJ8CxbMzxXkAo+CCGY
+27G8k8ssI+eYAMLbtTF7xnQgAjpMZzAJT4of1jvvw/q7Gj/t9gykkFBB8xvjAxpMeGG56Gy6p0uA
+4DYWdVOiswImswFLyuik5WcwRcFe3/hA96tbdYy+V1r9Xrv++6iufRpI5wtk5sg/LqSTODe7KKCB
+eWS12uqeq+3L7jmtRyer22/hQMhb1lD8FDOmL+qnnDlAfSEUz11szRgwQWLEOb2x1BK/hUMWbuCC
+9yYvC197nab6b62l9UOWqPuTC7XR7RguYlEuCEE9tFFyALvApWLnFrxvzbLabluUyYpB9cogiwcG
+Vfi2uNsF9tLt2JcR5zOiS8sSfDhSm63hl40jPY0uAK9lqEcfqloc44DVQdxaAfYtAE+2cG74Jn2n
+CmuVTOHHOtgjgaf9UuOX6r+DeLXZGtQp2YzyUib+ZnYT+CgGr8UH8NVos/aaPQNA95eq9XC/yr0h
+4Pqg0W714o0u+k3+jWMgX9ewhMM60x9o3U9DxVtm9MUUZ7xXFYaT2kT0Mg3ItlX6LO7Vhu22MVV6
+5Da8Nc0Oi7Hau6MR6ZT9BVPQ1eKvdViODYNpuu1Zhx56obZ36wOAt4fxbHuVvo07+NQ87DbqbSQW
+e117hUt0siDUcCFDlqZJTaE1LYoqKIS9yjwrjSEAcTHal7csFaLLYkLTUwtjZI0Gz9ZZlz87QnoB
+WCCJBtaEjgWOdNpb+I+lBFrtOLVAZBUBiqA5taKsyGxARWtmBV9WivVq9YZaxKDmsMqkw67agdzK
+X4TJAh+d1qy23MTGxLOioVoGfK/iNvQvldC7F7X5CxAC2qEYcxLH+klFxKZdKIZo5vZm17Bqo6s1
+1eYoi4nnj7sDx2sfGWUTTly8uBckkBwqOUiQ6ulF/BDZL8YzYWggkSRBSjmBcKIz7UtPCUKbLaMo
+KOui4NwuCli7TotVT9zSxb4fTiHuYPgnylzsJN0gd3UyHDkUWAB2nHBp9XDABWuTn/aVWjj5aypD
+SnYZwrqqjox8BI0Gqi/s8jGETgwoect1kv/Zfc31P1u9V+jNp9vUdlfsgVWhgXVh6EajipD7CyO4
+wfaVXy/IeOvttvFJ38lT3NUxdFrrqzg6Lbhmo9tum7wmDLopbXVNCuOf9ruvGOcWt0Qu4zsf3qRP
+JjWQ8r0XkmN2WXtUTadrKV/xVocoV2iueCklo5TghapGWwNUdaDRAYZz9CPPseVYYS024mhZa+b6
+GFiT++U/CY2v3BcA0aFe5S5y8Rv1FfAFU9eMPy5f3JycPqbiv7jgDkEzPa371nKLpJE6VIPtDj4M
+8gkZae/96zNHdzat1r0G8m8vh+quP3jSUh8Dy0LqqB1U9JoRcfsR0Fo/11Hf65Z/ivPGCsbYW74L
+74basO70VVLgPLELPQJLC9MDHaLCk+BMGn7FDMKAumSYvXbjdwjOkEW1YLEGN/UGE/TR1f4npLEG
+GOkhVWCCzBnyqPPWGeSabRthRyAyWFMDTBINxpzVpuRFF6QlksLYfXvLDWzj8KChXk/LfXh4l0Ya
+1GyxlwENWphB4JqjYW8SRjpo13tBRExR2dPeuqZY9OP4lJn3X1uDr3rABJpVnfwibDyYxRRGOBjK
+91rX+mHD1t4NnhhYJ3htv7aQzwdzJJ2xE3kSmWzCZs6JF7pjE8jhDbbb+PodtNiRHklQaCjRdm0O
+bd6bQwKC+h/1JuZ1RVqDoKz0c/VOx4hojIAn+8h5xmtIMAWaNqo+ezJYFmV53diZiOR/coHqjPha
+XRW6veYw8ugc9B5GBIMgjkkgN7rGyGwx70ESHdQ3mh866kJ2z7M6QJdNR+33/cmwPw==
+	]]>
+	<![CDATA[
+	aOeaFHKv1wxoD+iLyvtIZIPN0upmq17QsVUdehhx/2MnbibHib7YhwZRXbTtcXsJeJPdvepblwHT
+pPMLmytQ9Kn57iZr0Ufm9nRvejA/bqr91nvHJmAk0Ii9xo0IssbLyn6VWngUgI2GC4pve2EiECVQ
+f/jaD5+56B0Lkcw20fgryDojTMtOrb7Lrx+8hGDiByTYNrDOFzLyfuBkkh45NNhlWO9Apc346+94
+RQNdVAtRhgBJFicreNEVjMjhi/WjKqoJuCnVc306uNmwr1a6jRL+jCY8kAvA+kflrG31PcpHuDBV
+rWPfSQtkXbR+sJo7aLXNDAVPiUy06kanb5msnvJzhKmO1iLTbfjL+wHMhVYcdhrGtPouR7pA7LJV
+VITgyjaFxWnCF43aNiPe4JEX1zvVr1e1Sf0zowa+aO3snLb+VdunqvamNgZOtEIjeKDJBbAHesSE
+y2YfcVN3DM3U7ieivoQAR5HTUUd8BZH8dEYfK5cVV8egELM1DoD2XEOHN7dGJ+240jPBR9s5fX8b
+AYhIsXbTeOvFqaY2Wv1RXyK8wkHQFEuvd/TEFfpGsNojmVqX9pgkexdwT8XDcTkyKx/df3ZbTXUU
+LslnJJsyeLzCCJFc1H+pR7AsW722WnQ6sEKdt7bzheKzVYmQRE4rtedLrd7rBZmpRsUKnlHR0TdQ
+2i3D2g7hX8bXembe7+OojM/4kIaAlLudpk1DmOzbvSas09ZbK6JXx9kK7tGR847QHhx7FDbk2b69
+/ACTJ465/IMPNa5z77jOJPrxfz7UTrxf/4Wt1jv2s6bi2Il4vY/FenJ0pWaGvuTiV33SJPx1Nva7
+O4zDEunEu524ikiBlhE0be693uqgv9AGKBMHYOanHZB18UEXm2io8RZxLtbj7fpvDLPBMxNadCXF
++8PGB3Zvr1MhOpvVDIXWASYF8jPefbPAt/rxYecTM19zkXHa0Fq9YJltVNYnbq/TgLG5SDjoO5/J
+j/o5OW6pTBTmcaBeDIBhA5sIrMnScVGrudjQuq/1AT0vKXDVh27rR/3Isf3uqYJF3yiPANY/TsC2
+B+P8PlJepA+aCHb1jZ9LWxJqoD8hcsza+Ka7q0u4L0n2oo4DtULjK3PTyOYw9q1MFRUUjefY+8DW
+BbISdT04vB+kGmgllofHC4m2upeBNpCj6nmIR8pRuWRTHcNrH5omoqdPxMQyMcprWvcL5Pw/Xe3T
+DmW8L81xj/fZpB09D7ZuLW5DLAsMy7PUKT/3g/HRpdb6wi9uQkxoEwho63uBbnqjJuGupXoIw2N1
+/QP7EKGm0d0AN5EFnxq7gESnzulV+ajb6TY+AOVq2bKRD1pGEJ23b3D04woISJpl5uYpgqcbxt6C
+9S05BLH42v0VgXd4wbb6zYlSwLc7Wv03Hm94MZK071fbhpyzYd2KTOM4Hwljfuk/urAeek6It1fL
+G6B7KsIGOT4iCalHx6Sud3ijMhSOJz6CJ4B8F0Bfgch0fTwONl2fWt0NFOsgm2/UV4zwijBfqH2A
+VXn5Mfx67dRb7b7TXvVjDCA67ZGVUZQ4m+Jdpdp5ud6j8ZktNZh1EbUR1H7CoS9tvp01sGQrNaor
+lE3b0Hg3YnJa57g4jxXBrtLjRtACN97FyBDsJWjGFi/Ke3uyWFFRl8FW05viSyG9df2aZ/Lpo0x6
+62PA4xMnrJ+t8uaLM/OJvFjjty4HpcqbsvO5O3++Ua+8MXeb5lsuvXEufSSWelcriQxXK8aSiczR
+jZpYXnhYhqfbnUSK3/nK8YdKIr25k1gU+vzCGYEsbJ28bDK7L/tb2C85vSmtzFdUrTSspo8ObyoH
+e4kL423lM5fvi7vKy+XORvWmpJ7Hktv5/vv66tPpkVK5r2x9rG2xcq6U+lq8KD/ttSvVh5d0nV0p
+Fjpiopw604GOOyoYy1Lv8juR+fi5m0g3cjC05+YDDvMisbzbz+DPO31oG73khEOLJcng1obv10Jl
+Xs3sVbVHTS7uSt0LGNW1XJlvDquVrZUDce3+4Ki9nsx/l2Foq13b0MrZlXOhzx1KfpPIwezjkLC3
+C6OVDvuatta/1B7vM3tMXrhYtg/jWS335drgmvvR/VxkmossQeqJhSftiemvQ8vyEGmMTDLXPzLm
+Td4R5O+1n/Bzpw1f31WcQB+1p6PHM2+gO4Uf4urej5wLqD4W7cfC8SEB6wVUah3sJL2BrieWtT6b
+1LyBnrKPwhy3uhJLeo21v5Q5yvoAFT+W60t3VW+gwt0tU2NWjlxAAQoBO1drSguF89SxF1CmdnlT
+8QEqzSdPL4pFP6AvzM78/RVA8Rrr3E52e2nvNXfrOauPP+uSDvR0acmFXn5t0G4SoECLr1UCFKHo
+s3qnPXH7xwg0NTqruQdh46icBqBCd4SUfqzXfIGK7ZO5QSzpAmsCrWs/FpPXPkBrDamzJPGeQPvF
+J94FlEChYHeF7sNd1xvo+txyf6mwqHkB1YYvbDK1vPXw5AWUqSlVmH2fsUrzCxfX2po3UOHuiak9
+7Z57jnSu1l9LfuavLyygsaQN7E5meOwLdEl93z7xGWkir/V7pwsIdGUEvWc1WC9bhe3EEYAt9Nxj
+PSyU7nSgd9llF1Dp4vDzmgKtPn7WHCO932YOH6qiBRTGYhvr7ne/8Dl/JnkCPVrRWr5Atz+fy0Uf
+oA8poOSLVbXvOda5g+zjQVPNDDyBXjxvrfkCPX7c3S9ZQIHGHGDLzPXSrewN9HB+ePH+2pQ9gV4f
+sl1foLHk1U5+p+031gPmusdv+wDdSl3/uHkpegK92XpdsYDCvDjBPj8XBzc+QB8F5unkMuUN9Pjk
+/edtZX3FCyjMy9Mgd+Y71q/T9OKtH9Aa83z2ve4N9GQ7pT0U+2UCNJZ0j7X6Myv5AJV3EzfHzCEF
+Wp8b7DgXzZY2vHkQEGjaBTSW7Msn82upH8OvZwC7obmBvqycL+hAP5UVl6RZZI6ORQKUW9pc3nUC
+zWn99/15BJpFGnMziMNc4nFeqgHQ7f4IK3zsKhTo1nI140Jvolg7WaJAnwar+xbQWBIQnLpKr+1u
+7CPY/CgrvGKzhcPFnwC0NnQD1VpbKR3o6lnOOdLdq1JycZ0AjSX5ravDQ8dY5x/64uvDKQJlRrjS
+sbI4dzs42wOg3Ah31oqvnat0kl93vdUlsqaV5KW7q8PHfc+vh/XEOrP3mB74vF3aZOv903mvtzAD
+NdDGE8nSQgXfj1Lj7mtHKtQWWHzrJht4+9EzRJnX245WOHnaFclbj9nfHQxkdvO+4P313mJi++Sm
+eubzdrB2sLc/33e9NXWYA+bpMJ0Wh95fH0jPx9ubwyWftwdvp6uF66znW/n4no2ZspTLjHIqZsGc
+y+zoW2nxqv5Q3fR5u758XV6/2SZvPTB2WFq5WdBaJZ+vdzPPZeny0fvtUbH2cyPFp1xvTYwdn3/8
+7D9X095fH9/+/OL7ec7n7dd3N/upyt5v755OY0npvJ71+fpp5cGk7tG3z9/XBj/0eFu/5TbmMoWa
+H8bU2+PaYO5E9f76jXn6WPq5N+f5Nnlz1rxeThxveWNM0zaez/jts+VlfJ8bWdMbXGnv5Kz0hW9H
+mJBWfP7qJ56WKp5vhy+rIMVWkuuJF5/3G6mV7ZuVuvV2s5da75En5Gg9wqQ2ld2Fn4R7gYl3WjZN
+M8vwPrPkvsOGXjlYYxOZyvlNInP94wKNy8vE8kNqiE+nYGJ+lhPZg2fQhW4/C/SzzY3uJ/TmYpvA
+syDnj+TOEmrjG7dDYu4Ac31bN4HO51sbrynQ8OaqYO7knXxTm+OWNk6zurGz0LWL4M15Htn//hc1
+dl4Xzj/tcp+A1YEKqUd/oHO1H1lfoEytJJ24gBJtnIAFxbjDrz37AL37EQB0JyH6A93Z0e5scp93
+jFXenf+Who8G0J22Heh64skOVLhYsKP3bPvcBrS5uAj6mAU2vda+OvYBKn4gtfW8gQp3d/5A52rv
+jGNVIlg7gsF28AEK1iTYDq9+QOsuoLGkA8HMqi9QopH4AkV95MoPvRliJfmOdW/RNatsBnQNAp48
+6RNxPGwG14sl9Zon82qUFudONhIR6mnD58+kxS10SnZ4iOxLF77OLKdL3f4xpX54KqP+t0cQY2DW
+XPE7J+eA46OM/meLoe4bffZ1D5GQObevp9NFYI9LD2W9D/XzEnEnbfaWm5duxgTgS/kPtZLEP/Mm
+AMMW0wEYaxH681BhV0o/a1iJp01YzqbNzWrS9gc4Y9lU8l0+ujPs5jepQvww+oCtLjP7YjJJ/iAx
+OAwNfeAn5ggq6c1XfteGQBved65O4ediksiX4Up4p/pGFe8u5Vvzqxnyh+LT6fM0rVeK9MNhONLJ
+n3O7Te4xvi324NAaH45ldIT6n/ptxZpBr/njt64vj8LmL3PUjSX1ERKLyOX6pONbWwlGVoT5A0qm
+M7hz0RkPWf7EsHPtJnbDQxJI7l7IYt6Wvm+DKcuiK0LJ/pTVZesLS7sRMB+Md8LH1vJTY95A1mvf
+C+90XkKR5WI9d5mOm/VUH8s9OwBz9Nh8LDnGbPyostWn/o7ZBO+NwJ2DRV0p81yV1ceTgW9/SEeQ
+t2fwz4Pd6TqCuypa0AeOVWln3J6rMuU7NH5h7eAwwtBiSdfgHEN7nA8cGkH0Il1Dfh1h1Przle6D
+HRVH1qhSi2RU3sR+l+k5xYTngGKes+UYUCXnoHNzGTronFFPc4tOXd02TQTK4/f0iHlbXb73k9Kg
+85tkY8npdEBj5dyDb2O+TZkS2bXuXrmue93V5w4jjNlz1dl1fuhPvWZW8pnLTDVD/+hzxXpty52h
+lJ6zptNBY64JxT86FyRObA/aqM8dsb60kf/opjdIl2JJR89Wv316xn1zpXtl33uQmdKyhxaWdmLM
+NSWfcs81JfD1lRYo40JYj02K7SBiaj6CyVtn9KHF5o6Tq3I263Xc+f2Uh1G1J1O78Nozpsh6TQQj
+C8eXD+4Szv6nMufbKas/viqdo0sf8/6ycttateHCY8el0o0oFs/DpUCd3zGDYSpd9PnTYpawmr4x
+WAD1qldTseT4jYXZHaNNmdzSozEnzU+HsTC9bozGnJx2Sow5OdrYGNM9WzqhcaXbu6zTcN3FpVKN
+qh1bunEsOdLbwWYI57AptN6r4H3XNQ0efMxSsL11hV23JT7Fqnzf5Z6GpYMxDGWh6z2Tg61kLDk1
+diKYfbFQ7OycfkV1I/iMZbOPerIPW4g+TaMmnqsjsShdCeMCoR3x0C0nwonvsjfnxWUbvvIpTxFV
+un0WxrMM6ZamqVv2HAFOq2SL/NweULRcGYwHwOnUsOkwe2ji7ozBPnwWCJhhbglvt/gidMrepTEY
+gD3qZnTJ/dybDQNADrNcXZwG6bbxba2eHXmND/SxMZFeGYRpCi6aBU0+NhpEh1T71P9gZzS+zZ27
+nqFbRvN1+tnkP/eYN3buzpcYYsmxkBW8xL2QRVpx7r7pyBKnQJZzgW8MyAJ3yMotdg==
+	]]>
+	<![CDATA[
+	fxjB6g73Lu27FrivhyTIlwB68kJwb1z6uxmjOEpo/MIqOgrCjOIILtl9xJhTg59oaMvBQ4tFcHDs
+j4jlcd0bZO1/7TNq//NmygHtD319dDE7xwv0+/ALyrcQgQK90GKTL4iYZ20cH4ifvwZw4/TX+FGy
+jRU4PA1OVRpDkxmnKn3gVqVND0mYMj0yB6tn82PhzqbBntj7478n5a0J++Cud0DEIJWVQc7NcE0Y
+hjaD9XLgloFj0zlibPUs4RR/kb3RNjrfukryvgOKJYMp3UE7d/4+9mAGYNFY78At7yZgAIAWL2ch
+iRz2E3U+uixipzCWHEJL3NBmR0VdajntjN+AUd1eeK274FXn51UAJjzh/oRtVGr9OevaFQ2Td77S
+DhvLR1sv4f5WbIyZnieXAaPbwyl98WTWRkSe5x5feDtOQzK0N1574qSdiVegoxXdljT1sUnbiST3
+MFIlRPKRxpw7hGMJUSFz7oi2xW1et0mJZVPvMJgcBhtz2F0TixvSV+emT5Q9Pl9UXkZEpe67OHfZ
+5x4cbcWDo11F5Wix0AgNWBtTczTAGKiVIWwoOkfrf3pu+hCv9Zg7SNgYN72mhLlaF3PTrv0ri6NN
+tfavonI0g8YC2pmeo13NZu+V9ObZd+tsG2lscJXXqWjUszU6YWuMrwVtbR26dBS770IXcHpXlsAA
+3lxxBXUFBz6MFXN1e+32lE2wJQ/TaTFZKisn38jFxsKZbCwim73rRY1+8GIzxtp/W5rYaHTMWiUd
+jcOEtpMdvzcOWWm0M3UIBGnFxoKDdt5D2/FfOS6V3Mjj812G0NiYXj8PWWh6el9SGQ9peDO+fu+3
+jwx8bHr9Hiws/6iFWHI8aQiN+ZuPvrLQ2weLjc1g+dTn1IXppdhNVJdWiBS7GV+/92qFzP700vAm
+WBbaYuHC2wmQhsGycJTD1OeOuPGloa8sxJDwDI2IsEnDkdiXMcKRnKO/tWShsfb9gqesMAxfJgT9
++uFrjlJUxkYXpI/HAo2FEI3Sd22P+PmxsUgLMoKmC02JYV6FQF7rxFgnGTyTsYhuVZzLSOvcc/fU
+svietSDXdUA4nU+X7IvU5reMsrw8jLSch1i6c4mlCP5kXyPttR8glhyRa1Hs/Tt3LP3Yi8vu7eFK
+t5/BtlHUaFts6nvBf17G2r3BxgYhRBzZQ3IXyZ/stzPgpOTXPgm/jdiYj4pRzuW9gm9NKHaayPt2
+ytalALfwyOKi8+L2AVnLAp9oULgHPHu23PL5QgFPZrnAzLjDRFbOPlsZdHgKzSxy6IIz6MyMoSlz
+6IIz6Gx7r1Pl0KUDM+jMbMEpc+hMoJ4ZdFbk8HQ5dMEZdFa24HQ5dL5ASQadb7bgmDl0wRl09mzB
+aXLogjPoXDm8E+fQBWfQESk2gxy6dGAGHYEygxw6DxZly6AjUWrj5dA5A5L984B6Lkvc2+y163X+
+GVjbwbFntEvhnt7TRS0scHvjdTlYOSdRBA+VsDiXqC6m00XPiNBJPL2Ap9NxYsn99/hOl/xjyaPi
+ieaVjWTZjEaarURIBkNfZjq4Sx57fAGNZSYcnytnJDxzLvr4cmHrJTLSXRk8fl2KkvkY4gYL6JLB
+aww9eeykuei85i6juSKHJ0mgihAKQqRYhGCQH9Vp9uacEd132bnph+ahuntE3YQmu40fCjJi70/o
+MR6ZK4ejyt9KCk12GyMUxI9bAmIC9nXHMkOgKaCxaBla3o05Q7DAZt1JO1WIGrHJAzMfI/Ks+txt
+cIjDvC1bMNjsrbmSTMO3n1O+PLleC05hHMdxVrP2sj09vQ43iY/jzOk4TI+6SZo7VqaAwS0nz63x
+T+y3Z6VFywN7GASrE+Pk8QUfXRA5zq6549K8vPL4jrqW08o/NW1zsLXv06URVTo4Bh465R8Db05d
++PzRPL6FMJkbOY+v4xkhbst5j+qW2gnPiXE3RewX38ZCTkGI3C+yZxGSJDPOIJ3bH1NiLCRjZjyM
++W+FTIAx78MQIjbmdPwWtJFAJ5L9NAsD4n03OHUpZl/svk2EpS2GNWDzjvo1ccnSPyHcebDlv7Yd
+cbDhxt6IazfA2PM5I4Ir3c0tjt+Eow/PuTDr1ZppH5xs9sMS5XxmyNJg33fdOyP+Zph/rl342g9H
+h/8WYzAyTK91aJacS7z5aS67XqvcHTs6H1WP5J76rzmnHrnnmxVr5li59Eg/Sn7qd8ZxW+im0mh2
+rUeCXCDX8c+IckcQTayPQZeipLTGIq34p8Fy1OXqGYdk0Bh0amk2eHLv4iAJOO3KyCQQlhnn6pJv
+PjKms43lkQnoEj+eFAvKsAvyyBhndkXrVEhSnG+XRs/u2GL3+y6PDL+g9EJsumCPjElj7MHUbot9
+X4+MjcNENBu+9sf3yPjY+zC0pemHZnpkvKI7oqehRfXIBJynhGlo4wUIe8/VSEbqBB4ZzEAL9cjE
+oiAmLNI+NDlH12EQO9J4aaIBURLbQ5eyrOdYhUXTRFGWewezyEncumKDJ9HfNnDHXB1M49RxDc2K
+nPWL6Y0ytI1UVPr0lS+9g0ihC6HpYyR0ITxbMCyvLkroVCw8r27q2PUeZj4GuN0iBYjYkuv8XKBO
+So4WqgeQ55dc+6hQtuwfkWVGdkXYfJg8H85xeoOZETfrfLjpzh+Lmg8XQmMzyocjvovpksAj5MNF
+jlCdKh/O0pPtGXFTjmokHy7kRNAZ5cP5R0PNMh/OdpORZxLbbPLhCI2NZMTNOh/Oc15mng8XaIv5
+bOugJ2W8DTrffLFaMAFFjokkRwxH0S2jxESORElMtvavpkmvtyIhr7vTqxO0ldHI4LF3eLEdl/Ec
+3huPU85IO9Pm2NNWjEVo5b/YNmnGini+CnR7u2LgI0U8e2zlYQpbcCIOzUiNsAxhIqbKiKJ+y/Ls
+DgLGpq7dKyeUj/kuw+rjXeR0Ul9tHPA97SkXRIbP5DRg0k7o2TKh1itpZ+xl6CXFsJ3plyG24iML
+fU/T8g2zxsacRwKHnYa2+h1wWiOOL+3yYWFZqCo9alB7ZqTezCIj9fF7hhmp0NjsMlIfv2eSkcrO
+idP6j0h+VsarlXEzUqGdCfimZ75YSDp/xN4w0Wyx0HaiHAPtjOvzzd+CBRJwaGq0ICN71A0yiMzI
+MlxdDpmIqNG29mS4aSN6PFPhbFIsSkSPc5CRU+HCzoKeTSqcuSqNZLjJ/JYhqXCT2pXjpcL5nkE0
+01S4kNMbZpQKR8/rC1ENIymG5VxQbrWDGYSfCI95dY4AiSgnwvvrY3czO1CNYGxWDmTMXvM5xnB8
+Hea17zxkOMrmgl82ejmXj7SFExC6gFl+uo/OO+81QnKzq0vBFGFGQQfHDugeoDN6a5wnOTuuRS+8
+PbwVKve164vt/KB0GEtWtR8bzxuXlU+2XMrv31Tm1f2Lylb64nKj+5KW4GnnFGoulWu3j7Umt7Q5
+V6HCiLh7bf7k69EEMPl4yzjnSu+KM9lt/vru1O6+cqSAba6WH+78kt1uAzLs8G4+1j5+V7Ibs3Lk
+A1Sax0u1n/yuiwvJsOvx/kDxWm1foHip9rsrF8t2H18qINntVORsQJ15Z+SqaROo+7o4vB6z7Zdh
+J6QCMuzmavWcL1CmdrB+6gJqv48vKRxXXvyS3Z6Dkt0WJH+gO2fz9wH38SVPWkd1P6DnAeg9Prh2
+AbVn2DHV6lXNOasL5MAC80nPxBuubOQj1ePLjCOm168m87KyWozQYnq1O6haohPGfCdYiqgZRWBs
+4XgI1HJQzH1oyK1bgwW0iinnHlEl7Nj/aPKarP0Nz9Ayf6+J/z1WPkeJ+8Vc+af2lEPiSb02vzx8
+fVPeJOfokn6P3Oi9ouN6l9w3yXlNXSQv3MihZ+NmQ5qe3tPFLhNyjrgzri/gKrOR4OlQL9w4l8j5
+ji/03rewy0YijS/KXQNRU1C7Ee4ZiYr0sJDpyOulG3Zevle4a9AFdLrFN8Nsuun9MFGy6bzsAC8v
+3HTZdI6h6bl0YefDjJ9N5+UT1O8Y8sPyBNl0bu6EuXQzyXwM3caOzTybzs9rPdtsOq9AkjFOCImY
+TRdoV84sm85rn8Zz73WqbDqvXDrfnZGJs+m8/CzO8y1nkU3nmzMy02y6SOdcTZ1NZ1a25dJ57YpO
+l03nJYxiyVln03l1ydqtnlU2nVcu3ciNOVNn03nNn75eZphN59UU3eGdZTadlzo4kjMydTbdhBgb
+M5suGGOzyqaLlGUzdTZd9ByrabLpvDRPV271DLLpvBiO896EWWTTee2WII3NNpvO3oCRS+dvvU6a
+Tec1z347I5Nn01kzZG2t+MuXSbPpvJDhc1vWFNl0Xrl0vplcE2fTeQ3I0sb9lFLs1LQGINkZqWju
+i3ef+u8hKkZwgpiZHpZwWUkTJz5F4BZ27WI299UFaxezuq/O67Y6D+0iGp5Cb7a1EynxKPreCxem
+WEQjgcoAoYTcROtYOYFX1fl2ySvSPqBTkaWPs0vu6I69CBpA1C5ZFmY0DhOAJzXK6h3J5HJaRB57
+z1/7TpHgEX004gTztCvdF91NlLNmv+bOOx4mqkoe9Zq7WASP8f7U19zRm/JCLu6KlkgXECARNT55
+umvurCzOgIvupr7mbjyP4qTX3Hl5FEcuuhsvV6k8es2d+yRwz4vuxt884reu0ra72Cc856p3MLM8
+i63Vs0jJr+GZRbEkDG51eeq8s+BYjFgkCt26SvqH1ESOtT6YxTH8eD2dT+yvM1IlPMPQP4gjalYa
+Imaa5FdnkqFdgfanZP8btuwbIMAjR/OJoMwp6MLOhvLb78F0tVzkmfSPhrqYXTTUxSyjoS4iRkOF
+BDaffkUKhArPfExNvRVCWnEdB+4x+xHbGUfk+UR2kXYmW4GuVmwZdpPmstsa8z9bMMIN7O7EWo8D
+iqFsI1hKRz8VEBsrByev+EcEjER0Q2NcpMhwm+zyReVPdYWgcqz7XgOUCNTWUu4IaihLh+1XRnP9
+YfZTqOoeITPlujuWJuGlR9hz32Z2g+F115XIMNna739GumgoPPNxbWVaO6BsnVI81W41aSdKPmdY
+BrfriOIJe0N8F2vOxIoxL+JxLRCvRIaJd3hR91oZSWRY+g7NTIm4DCe44c4rv/IuaIt8ohvuZnFv
+dfgNd5G08alvuLMyH73vuBtv+fidVzzBTXkzyUty3nE3xajceUnjXUs3wQ13sYiH5Ex2w13UU80x
+SGV6BJI7uCcJ2PBEYH3u2TMX1nb2YPTE2vrc6/xYRqhP5uMMEmsfv63s9snPuaLtRPNmBcZcYTvT
+JtaSVvCsm+kTa7E3/ufCnZzZ9OQIaUw3EfLbvZKYbDqMaxlmPZbh7YR+Lc973/wPlhk3ielZI7aW
+nxTzSWPyQ+VtsNlOz+uLarjfTmi2e67K20hu6ihJTM8asd1nYVdiomewAe+0K/3SmJY2rv0ZcwTF
+0OFVwE5FTGyLphiWc1miGDqhlHOhd35HUgzvXIqh66a8cXNcS7cfvmec2FiB8xz4gA==
+	]]>
+	<![CDATA[
+	jLAQsyh4x8aNsUjJ4hGOpoKmJJcOM3mOq/ssZB/nZMS7BSe/7tGMgyWX5M0qx/XOK8PVL+s5SEez
+Vi+Trz1nveAZaWZqWdO2WFj7NEnvcqtwV7mv3V1W7qvadnFXutwvl3KNcrmUP8AwzoueIXiSbSfG
+dO+S6x62q177wZ4n7rwo7MH/8jf5bPXUTkqOfLj0WuPELwlP/IglV5Lria5fGp5n7p+RmtbM+wJl
+apelM4f94rqHzZ4l5gb6EnTNXVaxAXWmpsWSWn813TfBulPThNuPwzWfe9jmln1T07ThC2tLwtPv
+SrMheH3t69wHqDRPbtfzy4d78AUaSwKCv/wTDpla9/LSF+jiofrR9AOqWkCprHSm4Z3d+gOtHj/s
++KLXcXmhHSjMC4A9G5lVWJo6ePKk0/lqxHprrno65x+pKTweRmpRSJ3SerqYPJQ8lM5jM1uwNmy7
+vSpBfuJtL2nnGzZJ/Jbp0fPlThe7UePHgmTzQ8V9Vmd4yJB/StJ3cJdi0Ts1ViiMc6PLxvkrU4dW
+WV1yBVb5+WAjeJJOlxJRp47Oiz+exgqtCs5KGyu0KiArzTdC03m6aSR66o4XpeUb21MZJ2QzrEsu
+W2yKVMewKC16FkGkVED/A2/GXC8BcVrbtDejdo7TtM51R5gVuflrFqbEj2rw9mUkH+zUp8bZMFad
+2b71j+oMdnlgaI/T+8d+VGdwbiPMubV6Jz7XeizPMnpH/bMApz6EFnMAo+aLhVot2Jh/lFYU/5gr
+aOSV67pvoKzPHQaPOSqHeeWGs7KRfd3BYzuDay4O6o66Ge+wKzyEzP+wK8tBY2TYhXtV6MkQjgCC
+nfBTF6g+YrPE/bPbAoRjtEQycyfxUx7M5pyDkfPHpsuxClPebN5YegKVX6dU33MOImjjzvvFXPx+
+7FRAa/6c/N4zfz9yKmDoXS6j8+eTmbK0cZ2dGTFc58JvmYnemP/Oeiw5dmOhl/+Og7HQ+32i94ub
+Jcb4WWJM8G1sJF3YucM7aRZgVO3Qflfa+FmAUXMAR0/V8Gtimhv1nFrfuFmAUXMAKeefNAsw3Iby
+uR95rCxAb1Y3mgMYFAfrN0Pj36jnjlUYLwswag5gQI6VLzrGv1HP00aOnAUYNQfQz0bW+zMyKpf2
+FPFSvglvZBvzUj6/27JmeylfsFdhVpfyxaIzjSku5XOsyj92KR/xjk56A17kS/novATdgDeLS/lA
+58dr+WaEJ7/gi/Hvr5zkUj4vrwJ26lB49NOdr6KcDeW81c+6xWy6e/3M7D3PW/3GzuSa2dlQk9zr
+5ze0pemjbfdncTbUOPf6BWbdufXkCdMRZ3A2VKR7/SLkV87gXj8TO56JTSOUPOG9fsG3+sWSEVR2
+AzsB9/qNlck18b1+Topw3+rnilSZ+F6/4KEF3V85zr1+vh2ZxQ0g5r1+wQOKRUhHnCoAmkxTyKnm
+Y6QjBl2EFUtGjjkLvNcvePXq2vjU9/oFCzqnlTT5vX62ufK41W/iE6hc9/r5kwXVYEOCpyLe6xcW
+BT2be/1mk/Medq9fcCuu+/gmvtfP0UpQzNVU9/r5hpORPZDAjNQx7vUL3lAxbsobycMd816/oPSU
+iw7q/DPKEgu41c+V9zrxvX7B+zQka2AG9/oFWE532WW/jNRx7/XzzC4wb/UzueUUeQ/mkc8huuX0
+9/pFXvtT3etnpSN67Q5PdB/f2Kd4+N3HN33eg/1Wv2myOez3+nlYubYt4ijRtlHu9QsObHX6YCe/
+1y/4PA/zXp4p7/UzUq684zNsGUNT3esXysdmcq+f35zSW/1mch9faJBGtPv4pjhMx4ronsG9funA
+W/3GOr1h9F6/8Kv4fDnMJPf6BSRbsHNptCtnca+fB3nZbvWbListqppj+WGmu9cvWM2xMuunu9fP
+xLZnosYE9/F5Zk+Pm/c62b1+Hq1EvBt9nHv9glvxj7nyuNdv4mR4mpM4/b1+wbf6IZRZ3Ou3GXir
+H+FjM7jXLzjQCWd/Fvf6BZvtFGPT3+tn9ivaqpzwXr9J7crx7vXz4YH6rX6ziR4kXQq41c952vzk
+9/oFK4ax5Gzu9QtOiPWSyJPc6+eHSnqrX6A+Nsa9fsHxwKZHccp7/cbXYSa5189vJumtfhGza0Pv
+9YsQbzmDe/2ChYPpgbfEw6GQG9HRDoWALlO5MBrxYTl2qQ6zxC8on3mXazdwDzMk8N6ZtujiY0Lm
+3OnDWnQs++UvewwxYczmhSAkTcBIgZLtzm53BBFmhCWWH1LDRDa/dJTjD5UFo/phX9O4fjGx8q6d
+5bPJ1UX+5kgsilK6/7GX7w7rS7uqrKxsPSzczyX2BqlEsXaen7v7Ia0uXFx3i7Fk8rNzcbikfvSy
+0sXh93Phs3n4vv35cvxxoF4oyvHj7vf1Bds7eLv4OGu1r3byR8Pr553U8vNzOZ36eSf+PPk6Ta+9
+9dL32wMtebG8pGn8QmKuq3bzSWbhYy11f9i4Bowp6aPlze+Fr0OmmexUNG1r9TSx8rRzlOBKJ+30
+WkPYZmrM1iZTu7ypMTvz3WNm5+T4Q9NaW1lt+LG51F/KHL/iwBN6puXmdzW9IR8/4JQkSNIbYKx6
+XXjW+u/780z+RPVkSPq8kPzSzf6gcl8rHtY2ihsN6wpIeo/gUun73IUsgqpYcklts8LFx9XCt7bd
+kY4TN8cHaWus7pEOX3ILK4vJ29MFea1dSp5e7OwvvVzsbQjK4pGUNpNDYZoeq9nC4eJPIIt0jeQk
+7mUTWuspjwmc5yBaTjSnslW2L5+XZNtOaESd0P2tJWtolvQx5T7NtC0srS52OaF6U/q+3s4PVipp
+RXjNl6rc7jaUHe1vv11dHhd3pZfjtCJubNWUhfNm+Wl/fpeMlCvdpat0WZND3TZ3bpZxf2U5Xckk
+h7FkbXl3b4+t/lhdL7fqeRYnp1NtfH4rTP72M8s97zYzTL7+nUUZv4AREVn8GgTmRveT37qay5HN
+GoOzzy8RU4jJi0KK/ASMbXdxvYiraVIAy/n8G35uZ+nPp76aIU/8wvr6S+059XDAvP3Yft9eO0xo
+0O8D2lHazQzTeTFfrNhflJOvsaT5KmN/dcU2zRc5+4v3jTfzBWN7kV3Y+zBeHKfISNmdw7k6KSOy
+8jhtq77zI9cwq2ftL3qrDJbldZEgHjOYsPTF7kqHHP7kaNuvP5J1o4GzNKkSS7KvPRbP6TjLmsxn
+AYhlGe+HOcvRdhpSGds5Y8ih8Wxj94T81Jtt3D+wxExh8ne1dP7o4pOHt5cZ8pZLSatNC2OXOQqF
+SS3IDNe+SFYzSurH9hpzvWBfmsAyKUMlFuao9apzfmgvb7UHsz+LFhlbD9n8fH89fbWmSZtXwnGx
+8NRcpnZliUvdXyR0+r174Ipf3cN+8eDm5sUiLy41bH4aA7+xkQpX2d1ATfCGUjdXud9jKdlXGici
+eYoluUr7itNLhw8/yGLnqqn6s/7EvYvYhEibeL7fxhbvcyRHhXtug+lOvn0enuttv6RuTWq75+yr
+kntZa/40Xwnp6vXtLo7l1TaWl5tEGfnKGh5WfF5q595XiqeNt8PKwV7iwnLVMMaBjmXTR7fo8MAb
+7LjEJ4d7qgH0KU/X+SJ3JZDe8otrD6L+VKm3zHq8Xu/6q+jqTSxZPClfPtUq7blG8fzycan6mt2+
+sTQEKsqd6jf0+7RsSt9Vl/R1y96VpxpgLJH5+HmbyFz/qCYyRze3idTx/TJK5P1EegjyDPTc3UQm
+tXWZSLXam4ls5+wxkW7kFIe8Bv2A+FOJrZXfuFsmIwUWViQsc8WMghYvenol4Izw8w7sm1NhmckP
+lnG6nwe1Knckw9PuEsaEfuOxkuh83k2RhYvOQvIT/tx1czpf3E48kTlFu7Kcy5AUGu5puL6Xb90O
+cnTeWpnVNNGU+IW16r6XhQma7vEBXfbmH3xxpUefbxZSZFHAvAApPbErxQKw682NtNHlA8ogkG/i
+WA6ABArXu+WXz2KTK91fbeliYvOQYcTXAySvA9bO9ErfEkzO+wkyOIIxfYSYWf9Y1FW1nXKGltXn
+9nrwc49WAcX47mepPdepsbvZGotN2Nve3TrnvfQ72/7+ok0r3BQf+5aOOuq8/HrgUqBHcM9f/H56
+i8tw7A77UGNf39N3RPiTL9iVUrOie3tc7h8W6LUE7P8LbJ7Pxoqn6ovE4NsHcjt2uZRjOBDkd8fF
+TI8B67XYODuuVbbS4n4x091OkfM1iHgvvRzdlJWq3MhUtR+rP9buDzubO+3r28firvjAbOf7vQ9C
+mo6FNL+ErDVNBqSfRUD1ZPNgDr4k87I03yuXS59LncdKrrDUX1MV7bN4MUx8FL53zw+r9fpSrnrf
+nPsgSw4WjTykiy/ZfSq71DgLqH4LswV2BOjq4fn2alVtlT6Xl8+qu6ctdvu7mC9W9r5afWAZbEnX
+ooVKC2b6fID69DGu2bn05nAxYVp8o7CDIa8dLFQeKzs7G5/Fywr/HWG4MBZzwNhi3nIoWGoeMY+N
+YyTy5FZkKqoNNe8FVpg036+mW/cfxcvrG80FOZYMRjVC5kClY/cmgnzDVXK59RuQL8+DJ3Z7bf/z
+fDykb61tLvpO95+isZX3/kjQPrIoEGrcknE7tn4Ix1EHL3zO2nQFpl/plE5Ot0EEieJL8XLt53Jl
+70HaB8jLc9vrW7WcuRa/Cfsnq3Lz6nmlas2zaydxTHxHxTbxKhB8D5Zywm7xC0TPheA79AkHDhwm
+2tCnIrRYcqyhjw78UXHoB9ff1jbnSAaEFyN1sNErpjKsf9wQNrr9dtlbq2pPrydi+/XHArw4PdnO
+a4OF0ssxd1FT5sVNy4ZaG75vZmLJUk7QrrmlrZWdGS52F8XHkh6LfQo2s7AArPX7cZUvV56Ll+Uf
+j2QGQOePtNjxpJjJeRvQWPiAp+ZtuPZDB+w9XCC0bCcrt02Xx5nvmOnJLTOaZGBmvQWvtQZjmZat
+R1hr5Ayi6dh6BBkelcbsUnx8yLHkH1FawqXYFEqLH6Jp5HAoqscYrhehjeRZTDPJvusqlhxdWdPR
+mJe2RqTYJHwFjaE7+z6ch0mZqZxzaDweg12Zvl/eTqTbQi2ReW7u488ltDWf0Hw8TqTP5tYSWTl7
+kljqXS0kMt+9E7Q14YmrXSSyRX4T/zTBJr3dTaQ0LZPIJF6W0Ld2bdksxh2p6ulGGu1OneFUH2vf
+WLNgmtTb5VZtUdu+Xrr93u7uane158zufPHkff0QECMsVN7O+ufEbdhPPC1V9BnYuJ8n+kEsyRe1
+RMU56sWokKv1l+rnduc7/wLgz+989SiQYk51Iv+R7GYmA3pWeVvszSM/fwXwjefoOgwA7WhOJWIC
+7Qnk/uSKY2RRRm4vjSS7o2lPpSUvbJNbACbGd9QxTyPFxtGUfMXo5OBHUA622Ez0h2DIOPtj2Qme
+kMP46+wscW6waDfNvuc1C+8TWknj6W2LDj0ZOzBDqRJgiSdWfrR75kJbHkE6cUbVvw==
+	]]>
+	<![CDATA[
+	826GY98LHEjol1RQdGzjnxL6LbnaMS1YWZpfRwlyiKLnEMXIAb7Iobi5wJ+1RGr9eBWdnMyfkS+T
+MgDCbmPJP2KuRpAvhNVPA/la3b4+2NiD9XeZqL5IJx/oIYkoWv9/li/jSzYS0xs2YN/hku3gCM4Y
+ki04q0nWmfr1QsXlFyA0NrlQ5xrPK9trjx/Pldz5i1Z+2+i8eg1c33v1UqKmUKHciwtt5PHmfBIS
+h7FM4QaLCtk62TjS8ppwcSGU2XITXz42jeIYabjW/n6k5TXhmGPJsZbXhAM3aCzi8oqyuMhmKh52
+P5LLY48S2XovrD6dHinFXUnCk8fXS6WX4/lj8lOpykNuRxyyF9Wb0sXhdn6wdVDcFa9ylfva9QX8
+ZGqri93KamW+KTGW6w84v9P5N7nrL0Crw3mZrbfdS6GLJWftp4jkIRl/c8VG+35M9s/ayIYWjRrs
+bP0UXgM39pJmb8TYbahYckJX5DQ+2DF3PAL06Un8YxN45uyQJ/aPjUXxaL0GmxJ/0gcbZL/Z/WOf
+ysqE/rElLZHdV26pSQLGSWEsW8VrlROJ7F7nxdrzZ3ulVmzXf0ZY4uSJhO9pw5fDgh6GYJhrZsRd
+5IW2tFxuJR5SUXkbnWI6+9mUVl6lwUql2+ZwAkHPLqmD8kfhSY1sJX2TdvDp62f/ubpK42poxPrY
+1LZ1vvJYvLz6+SPQQ2KtMfJEI0FXa9RNgvt5+lHcoVo07or+0Ykn004juv/gxJNpN6LU/tjEk8nW
+ZeWfm/iIuzxTTjyZdnquwh+c+Kh7fNNNPJl29I7+0YnXPb1/eOLDNdjAiddV+858hCh9wpND4/SN
+D1ccUyt8W2kCBP0jmXjWuXCI75QtLYFIuYXqD9FUjJ33ttDI/qxNki425ANbN0lZYrDcNxs4JX5L
+ZxPCyg6xuww7qOsYATFx1rNHlo7GLSt3vDV6cslNIllaMA2pxqLTB0uaKOVtTbC12x3Wij8HnOS+
+SKwjoZd8a/MKo8VPuxhquEnowCi7/jbK7jRcLyedtBWISsIOHYuK0EHq0ZYXgBcEGWSRwiuVlHk9
+YaB9dWyfYnKpDAwoloSlu8GlzUj8le2blbqxpkl44mmXpgQsbz20bWRBppPMAV84+dSvtuGGrLUq
+yX1QGO0+R/bEU3fO23FSFsZuE918lV6BpJXuHsx19bH8unD+yNbnhB3X3UiAArZnouAHQYGu86fX
+ufczEwn3diS47qf6lHtGlsI2b0NBcj3xYqBAyFsowN582mPhMJgyG4KErdXPDkEC0qKTPo+yJgp0
+oPotUBvEDxMFCRsDg/qHCYsOEkL/YTECHSAlr54OdNIupQ5MJOw+5eZ+XhlIyGV96QBPCVgysLjK
+ehESobHAJn6qy8FNhDXQ/0yhd3SKJujl1bSBgPVA5sWvCXYuPV0fSM6wsSona4JctRg6DNIAlWKj
+TZDUtGmGcbWat0hK3xcbj6jefmwzY1FlLOnmT5mlj+XxV7e9AaaTcjWgYyx6E8pgZToOg2k3ac8m
+Is4GmzlMZ7waiCUdTdh7MdLEFZsNm436+rHVAP/QZmW7R5HN/ChMRVSYSpT3bYBYr+FN9MpMKCoD
+RB5AyS7ssVT1ndvZLRlNSPMrDxr/bQO1U/pO6fVqP1mrXlI4rrzY6x3OuQnEi8aCRrVztTwB13HQ
+2M6PnCeJRKbznXfBk0BiyagrHjO5JiUQg8Z2F7bzUw1jN1vz5zrRaGxXOmSn6QNA2d0650JWm7aZ
+Z80mdoVB7mrd1ofXH8kQrkPkSxAmXt/T6en60MMTqKaajcZCIRuBIgIkMtvIbuQmZFx6A1I5P5lE
+JiaXyC5Tr58z+cqRhfveW9tiOFVs128fYkl5d63bLTALfANZxZlv7qozw+U7bb8Dll7nuEQzq1aK
+MjnsM2XkVaHc1zOrbj/TtJIzowhM2CHDpbaXDqntRyLDSb4YNfDBmI+QPmac1mi3xdBmBaCkRZd7
+gFFPyxW2UWAkKxeWX1AGEnbeTO90JFFiimIsSZIUV987S1e19arQpfrvUu9qEWM6LtF8HFjHnuoT
+sXN7pp9QZP2xziriDhWu9LDyg6b/VRonnI4xWwIydajUnyWbnQc/Bd2yeOW67Er54R6buLe+GE1T
+onnLPZ3zG5NMvCGnd2RWcfzWPU/ES4OmIqa9oWcjarYVnbrbT7perr8doK5lRPqNfRv/pbvDLW3c
+9kderBwUUdNNMeqrUGD2T2tl7E0GxvyUBWH0VUlTD4lxtoWGuFuWQLl9yBEssq+HV9sgz3ss9YM7
+hnZOG3OcU7tMEz2Xtg43SWYcxbbzdobDC8yjrvKLvMTrmXo0N8w1UjGr58ISeppfT+Y/uskCl8oK
+EjTwXmT2d/byzh7e0nPhdgCiCIT4+qGhpBH4rasctDj47iPDZWCp7Gl0QO7FUHtO51uv9SqS0pbN
+GUNPfTHS6AjGvh6Yg9WHTe5lZX0HZ5CFGbytggL2xcHQmFq+lRE2kCvJbIatb7O7BeWEnprMLOfu
+4YsUwycbvSowzy8Gv6jkW3c/Klxqt4ZfHCqxJJeCWSPUwSebiV2uulKSSFoj01w+v6PZ4WBPLZnz
+i+6I3RXH/B7glPSSJu3bD4pAphDzfmXsfVy5FiSjDrZlsgTMZOIftpzE+sLXI12LSxt3NDUWj/fI
+EM/VfFbPawYUOlgFLhD9aZn6O2BUK/pYcOUAEWd00iU/yzlU/XZz5md5kg5Mszgf+a3rXslIzBSW
+zY4+AdqWV40XqyvWC3vG/+Z2xnphUTK8qOXsuaLc0/DHtpX+aX1jB7+zShL/U3bIO9tpC3d2yDu1
+rPWCZHJdaVB6mNdlwM4Jg66cNPDarwH8vOJIHi4wqYGiNwGcHqtk9ETW072sIcCGKzpfOT3MkSqE
+ZaCf//ScwStWWPjTBB5yekubhSXeydEZTC3kUkbu/B5JVQUoZXZNB3p3krNt/qk/Um/lD6l2UmrL
+87JDvpj3I9PG3Pm61tkld+f54Ba92nNkpI60eMXYPLhXG6vl4tXi2kv5o3DQK14WOzduWZJq3JoJ
+3Ze8mW3+Ekva5/f10CKWuu49fD0n6bsZvLAyRZ/qc9fkgAdE+sUKfSrd87uECZGsZvKkT+zru6iv
+F13mfl7loIkd1tQQsmYWdhaWXHlD781n3Urxf7WnJ3++C0ZC871oZc7jWK5quwbDvc9W8vX1RVNA
+/wwVxotJpzBet9Pi4CFPDscg/uQiGXUO+r2fpk+2fg/eeVJmnM5h7410/7Xbrrwl+5fb61u3QvHg
+lpk3T7gRXRF3+UVdCFG2cNTRV86JukIp2UQ/oR1ygAcuBkY/wOOmWte5av05p7MjzFAHdkT4z4oR
+cwUMKc9Vsg9pUBw3MmZ+e5aczANl5Rye43Wr87udg5R+xrpYy3sfwCzuMRZ67Wd1EhaGzsuci3uR
+kQL7aD6QLqPzAFXbg6yesA5GeGV/vctYjItypwXls02SyqmNbD/bA6ebSGw0dnP6+IBd4co5wvkt
+kANMCKeiGer0+BJkUXr2+zFFJRpXH7YTQjhdCIF29X82YwVZluKyKMvx/PmwrWonWuu91YlnYmux
+fHGPZa86zW5NU9VL9d9BpdsYfqmdQXw1ni9elPf2ZLGiNrpNNU4OhBJfCiaVZnS60PkD76XqmtpL
+qfKm7Hzuzp9v1CtvzN2me1M/xe9u4Kb+OW7qb36u01DlzEcLXr285fAchQvcu68ksswRR/cM/E7x
+oUznXvq6X8++1LqFG55puqwLdLtvbrwWM73j/e0Dpb8p767f5Grde+G6qj3eM5X72t0lOf6HsPbR
+wwwPlYkOhljO1udwfPv4Zw0jEk5h1Is/PA6GSI5sUvqoAsYxOn7KwGxUAXMp+igDs1EFQNgHKgOz
+UQWoSuGvDMxGFTCvZPBRBmajCuhQxhLd46sCseTkLUZXBTDwPUgZmI0qgBvhQcrAbFSBWDJYGZiN
+KmAFjXkrA7NRBWJJlzIQvHluGZjBh49sSsnyEDiteluZbw6rgLGnnfPb1aeT7jI5W6yUamun2/mB
+tFuqMrlL+5EjUuLV4dihrhJ/x47l1qEHDyFn/AFL7nMul2/NnS7S2QdLsa8f3yTmlsgWJjkRmZwo
+RrZ1dYEsrqbx/JVNaiSZ7A++uGYIc6SG8TZeCJUjU4ae5HvKLb2PP99lXCckGS/QohxsfruPH6NK
+GG6C9PQuA/skSoquJWzumVqC8+SxXpkxNJUT1mJ6dHL0E3I2VozxHaf1A250TeUH8egd62rPTm8V
+/ZTH1jk9qs7Mds5tbQOxJ4bBh9TZL6wNDpgwj5OaIFzCCH4ND5iYJlyCblRECZiYJlwCwyCiBUxM
+Ey5BAxSiBExMEy5hzEt4wMQ04RLkopRIARPThEvYtnUju/THD5eIRQ6YSE8RLgEabMSAiWnCJXRn
+ZYSAiWnCJSJtU5GAiWn6gAeoRQuY8O9DeLhEaOCIGTAxTbiEtU012TCihUsEBo44AibGIqq0M1wC
++dhETYwVLqFvUUcImJgmXGISDjN+uIRH4IhPwMQ04RK6rIy87zhZuIQzcCQoYGKacAlX4EiQ0Jsi
+XIJgLFLAxDThEg4ai4qYscMlYsmoARPThEsYgSNRhzFZuISDxgIDJqYJlwAaixy0MXm4hBE4Eh4w
+MU24hCGRwwMmpgwciRgw4T8b4eESKJGjBUxMEy6hr0pXhACb/iwsoWHwwzAQjzqm8fVs+U/Sm6ft
+nO6Pp+5AcnYsepeMs2ONi+rRANaNZoBNTC7dsyUWiENhST89VdygJ2iDBvugEVe88Vktbzrq7Qdc
+gzh9tlzVByn7K2VgnkV9YD/lGgSPecr1gf2Ua5AG5nnBB3mnlftug+I6JBY9nMf2I7yB972annn7
+Ad7AjswDvI9zxNhB9kAPUsZVjgR5zOreUXpI7KZ4Zm8blgDi9kw/2hZocVU3GzJHXWpVA3khRZzl
+9aO1t/YQbWes/sXZFWmUyP359XniBiTxA7qTMCsg2VzaEMOltrbXxj6aOTl6OaJpjuNG+fqELXq1
+h9vtZ4cb1gaBODhdUHee7uX34sVwoVW9b56iL+WStejX7vi9+8Eb5HUp2I/R3iqYpHKT1eeFq5yV
+kUHc5A3Cv2Fw2x4txxvWcBPdkDsfuvjEm08CbaC69oWH8t9n9aO1G2Ti7/Pm1cviPWO0c2+jNu6F
++2H6Mu95+4vK54Luufn8KZouQsn3LHRnCrrr7HLrj/vs8ieb84dfTJ0gUp/gz90NuhGeWPPJcfw3
+v3j0LmCp4NGfs9rL9V25kpZTtVr16Fq2ZhX4mFpK29J7KEb2v3SmUHtO6UeZA/vYJz7atFGJHLKZ
+yeEwsD/GToXpXWPoGdLAjqgrbqW40XOwowt6TDjaPt8Es4SPbWdJdhVaI/ew5K4142jqwjr1Q4GN
+8eB5GRrYDo9u9OILZGF5i3cZ+y/AvdKUcRldftJ55GY5Sz1zT/3XT3rCtINxMdYp1w==
+	]]>
+	<![CDATA[
+	ri0MayuQbLjKrB6VdrUsm1FpOl8BTpXTmRThRKDD6G6+nROGuEP5hbX3otE22cIggWv9/7MZW4sl
+cSfwudpp2ncBY8kklFyog2EPK4jPJfW91Tms/1a1GBun/2Pgf/i3oMRZTo5zogg/RCw9fI0t93+9
+8wwjpOKHnVjyOV/UBpVWY9Dqdura7/gqFt0eHR7j/iL5Mc7Ltfjyv1/tDrzO1gcDrfU6HKj9FO5T
+IhytPlKr8dFqNzW1Q+tw8fxeZ2C9xT+D3z2Vvl3+GAx6q/l8b6i1c13tPd9s5NW2ikjp59kcm0/F
+8xcAtPPubOFXvT00msDy/mqz4VO1U//Sa+p9pHUz/xXjbmhqfdD6pTa6X1/dTp+goNOfjzzqxhij
+bvzXjPqff/7J/cOTwXIMrByg3sgj9q/rMWRS+b9uzKyiKHmGy3NcVmu+Zfu/O4P6v9lxph0+i44E
+Uvm/Bwmtzme/Ue+plNahu/1evaH280Z5ZCSEfOCBCeuL/w509LvNVg/+y/W7Q62hvgFG1FxHHeQr
+lxXzZZbJNQfN6OtD/2yMRWJ+8R/GCmGGXS0XjR0Y3V5tdht0VOEDHv3mPzxkJifIOTauKQWJiTBm
+g4BXf6laHzoZZcyj32SmHxYbOKzwgVxc7zxffrT6VSrro4xj5BNj6q72KvHVuKUCQV1QsphnUILg
+lf49/Bdj4kX47/af2DD2Df8Zf4exK3+dSW8cmhbkZ/Y5sHWqpAGE3/BjHx5+QtE/cZaJH8Ufnph4
+E6Gfx0iVZkyKL6fitzdmN9h4BV6dxJgcywoyr8ThAcbDi/ggC4woYOM5uSALPIsPoixzAj7Eb+s6
+dI5C5xklx4mSHOcLcg6akuNfMV4UcqIsxnlZyYkFhY0fxnhByRUKghAXGDbHFCQOyzgmJ0oAC+tx
+goJFIpsrKLIcF9hCTgFKJZ8yOYkVubjAiTlWYklzLAePikI+laHf2Bp8IQpsXOAl6BFLylghJ8lM
+gZQVGIl8ykg5UeQLcV7hcjzH8VDGKQiNxXpyjuFkUiaLOUkAFVjg+RzDFui3sIhYRoJv2RyvSAiD
+K/A5VhFk0j1RKeDIOAm+5SQYBcIXWAJCzMEHPPS4kGP5QoFUY3MKdFRgOEQ7qSYBBEUECLKcUwoK
+GQWiTFYQxYBPgZRwORgh1CoUAHMcp4+Lk6GbOBEsLxVIWSFXYGWZ1BM4lqB4ZMIOY2/eRFnQVx4u
+h4sPWNeXvyMJtP8kkxuHszW6nY7aADGQbQy1X/XBUIvE2YO//3+T4/Xqgw+eEaVgvuTD3JaBfsn/
+AQdxP5ivWKGQAwLngeRh5aXwM7nAsAxn636x2X1VT15/AtKP6lD2r95PN/254Q+0eqffrg/Ux2Ud
+jJABINj+Y8rWPqkHqtGXAy9FcwqxXccrq8DJwEVhLAbuYNKRJITIBQNQ9MYY4PQmTzG5m8WibQzP
+5NoWT7G4kUeZ7dOP2E2sEzuL1HEmDDPjI0MIIcuJ2gydwQnaDJk0V5soM1keJAtKKokpCDhvZpkk
+g/AUYLo4BeUUPMArIlkByVBdsgoaIMxYrK1YZZzEwYNYsBqySgxw8J1RJrASQombDaFEBSljQTML
+GjGzS1Ylo9tGO6NjK8d2gYqOo1GREE5FuYI43RLjx1PCxgfAjUcO4y5jY6bty9ijbLJlzM5myY3B
+uJkMX5Cw97zwZ3g2O96KH+oatMjIMgvKMDwoBVGGB4njC6SE40BrRrVZgHf4Bp95gWVBr3Xr0ZwI
+Kh1ofSAYOYmsdBEUQBa0XbMM5xbUWJmH9QRKpwDaJSkz6kmw2BQey/TG7AWwSBXQ//BDllFslazW
+/2qBf7XAKFqgFMJ8p9ECRdDOwKZjwNqTeF0LBObEK7PVAnUwGQSC7f8hliJOIUKQv1ADnm7H4P9u
+i06mwaLZDzyRAdvxn/8GFtL/y0L+spAoLCRE1v5lIQYLkUKVRAcLIW5AP1WFlzlJkog+wnGFAj4o
+goh6cg7gsMT9J7GiJGMdEbQUgdQpMJhoOqKwENMAdXtJyMkSy+vWCc+LVhF678ByZETgLYAwRRB4
+3T3GMJziLHM391ch+ctNInKTEDE7DTcpgITjWbAGwVBSKDcpFEDYCbPlJjqYDAIh7f8hbhJitinB
+yodL3/jzHOCvPvGXA0ThAIUQKfmXAxgcoBDqOYuiT9i3EGerVYB5wklkd44FxsCiGUPKFFEhe2JQ
+LsWxBL7HXTIhp/CiCCUFsGZkYB4ym5MYAFoGhgKGCluwlVEmwwnYvgwcSIQ+4SZcoVCQSesSenCs
+EoXLCQzHE0eoXkYcmBLwP/SECgJURycnz6O/lRHpJqNZQl2hiiTZawGHlEBztFoyS2zwrDKjV8Rj
+KsmK1XNekAEv6NS1xsyLPMDjFfuY0SMocQxLsCUK+AHYcgx6oXAzkjgLoYDlOKiiwGQpgMcy2Ytl
+Jdzr5IEv011csPdYBbg1rwhgRdI9UfxUkERajyH7ibbm4IFXoBHogyIxAFoBaQAmJCmRCsQDrNDp
+RZBATqKCu8RMThFFSd8SZgoCR3ZJZZbuf8K3PMMVyG6yWODJXieOHI1YgeEBr6D+YwmgD2uh6arA
+pEP/CwLuETMF3JiVECZGRSgKti9jW2QvFcpEGTAmsECynD4mlm7ICowC4knk9DKOByIVWDYnCzhd
+OAKUXQLL54DUqeubL+BeMHSCBdwhSMAe+tBZJBiGQkSE4iY3Cz1TOEHvBSewehlXUHRhyko89kwB
+8oN6vCBCvxAXHMyXzCJdGLveHGCMJ7513ERn6SY6TCGrEMwCp5EZAesJOUaWaft8jmORqjkkGiq/
+cWwsFsE6ZBUcEg4SKELgCjlgVQCSl6EpeBA4hW4+A0heyMFKE0ktCSiNgASskA8VwCvxK/B8AcgZ
+P+WB9GAQpEyETwUsQ6TDkiIfcjhKeOAYHkvgFS+h7xuIAUgKQQIkmcw4z5kjgl4DPmXypcxzNFYA
+VqWIWARAIsPTekAHHA0VEHkORonDJZPLI2/BcQNOuAJL3e2Ei5RJEIMkFUhL0G0yIpwalu6IyLJI
+xk2wzghEhOhxCPAhK5CNE2D4IupCLPSABZwLiF8ONSFgEbCGOVJSkGC9lUnoA5ArR7oFREFoE8hP
+IBYvj4SrlxEChPZh/nQfDtYrwCLEIhElGgYDSBQkvEFaw5ABAYM9sIQsNwAJ64dRRApSBrZEwghw
+cSkUJPxLCArqsQVW/xaXA62H6iIp4hhYIbi0BR0A5aQKtADVSQkvM8gJMCKDY5HfInlIxLmEIRQ8
+jI6UwWKRSJmEu0+0NQbnD8uAzbEKQZoEgDhkqwXcJcFFwOBWl4JCiuAQpgrrAEQMVlHITAKrYmUi
+LYA9SnQqATRDeAOHQoil4y4AEyVFyNuR9fAYg4K7ZALGiVCEAR1CH2QQ78i0yZYYQ8QTFAkYEYJE
+TvqHLaFk5Cnhi7Ca9TIRY3NIxwqEeLgCAAdSpEStAMfkCkDmMhFHwONYICeuAH0GKUXbBxaHMHEL
+hScLEGhTpCKxIKBKz5MyUSgIelALiaUhC6VAq6FAhnYFDmmsgACgszxH2QARtJwE1E0KYFmJBYlA
+RKHPGuxJD3KRMTwGOQNDA1o4qWDUgvEwhD1x6HsETYiyLLmAO5SAAAExxiGaFCxB5wvSL6wdSQGK
+K5PvwNyQafSNwFKIKDAQX7AqCG+kqoCEsgkFcYElwTEo5sluJH4LjASmUgIiQpqjyw4KRAXpnSU8
+n+EJE8CmoDsCkStA27zeFCcQGaWPA/2luP+G3QVZI5PoJk6UUTyIpJrCCDJRZWQGVorAQB+wC+hq
+EiWFSkB8UybbdyR4B6UncA9Bb13kULTCguJE3WuL3E/iiUQlS56WASkqpJ5QQMRCCcoJwAYuQCGu
+q1wCEfScqAPkBIGGPsHaMwBySGqoNbAibzTuVOD++nH+WnHRrDj5D3qFgVGAsJNAp2NhoRErDngv
+iJnZWnE6mAwCgfb5P2PEyeM5hafeV/prk/21yf7aZH9tsr822V+b7K9N9tcm+2uT/a+3yf7urP21
+ySLZZH9wb/3/LZssNCI6fGMtUth4YbzQ6yGx+IzNOkXhkWHCA5rbuCPHiIrCFMjs8DgVDFo0EqkD
+TBx1IMzSE8CI8sj9Az5MpAGo5KAJchgAAI/EXjLLDm1loNqAJOX1MjBMJMJ2QXNHvQdVDk4mJUoB
+VInrGJaxBm9maNagXkT4G82jQx1HRAmKphOIYJo0B8Kd2FcgLdmCrcRsnubzKUSxgo4xMkZAmkOC
+EqjJkU6A6lfgRav7owO/i9X+MtS/DDWcoYKu+wdz6NAikwqiwsOjRBgqemDAtJxxEh2FAywVNGd0
+8fwRlgrK+nRurhO3m2uEf3HIemSyjEGrQvbFKCSs0yyinIrTXQwCSXgyqiA7UDidTYGmLuscAt1U
+7qb/Moi/DCIig/iDGheuV4Vh0UhheZEyCNAHCsyMg5l0OAIwCJEA+EMMYjydawIGgX4wRdJ1BtCX
+vqwyVEB4UaTKBqZJoKdbYcw8PKOMKDgKVXpG2vu7OfaXLURjC+wfDHFkBfRYcVRv4ClbAPEuz5wt
+UDioN/AEwJ9hC+x4MY4utsD+IWOJFczDPkRRorYSFDHoO8MyQSQubyjjFfQ2EicthlKje0wp8KSE
+F3G7Cv1eHNlE0UsaxI0MXRLstaCb6BPE1pmC7CjRHYCNmFlGnFbE20w0FlEkJQz2Cktk3OND5xQY
+6MTHjmXoCSNlOsuDMoWRqLNLRMcvKeE43a2FrjFW9zSTApklrmzitJNZUkY2h7CE+OFJCW6HYAlH
+NqZkwLRAne489Smihwy3RRB1rMLqDjLcG7AKWMxdE8h4jTJZysn0M5i8AjmGBtAqoK8O7ElBwCNS
+jJIGtXVZspmpl6Gbu0B2PYyWrBILnq2MeO3QiS4zZLDo2ZVlKFGAZjiRjI2l+19ocXIiRa4kitTi
+lDk0cbE2h7WNEvtkWmX6lJPGRZm1yIKcdSMrvJ14qGdfEOy1JN35S8gwTo6vURSdfHH7o0yPtCko
+NpJGPz9gR8SNPgXtbtwXVnB22QIZMMNJir3EhiajTMZNJZkiSpAlenYNV5AE27QYJQ1CBMRMt2qx
+Ct0PMVuySuxkYJbpveJZPROB9pyT4iMrtvxXh/8rrKMJ6z95UA5uDIiCAmoky+nCWlB4buYn5RA4
+YgaAkPb/kKz+0yflKOO6S+kRaSt/zmsKShBDAhlwX00AEYppU1yO53myw092Q3GDn+6tQwny02sS
+LkD2PTncckUJwDF6LAXUKWAQwF2M54BORDywBWpxNBgEN5ZxC4ruAKJUIdAUemQZi21ek16xIuoP
+2Biw9vhoP9GHgd4PElpCAiB4VtadJmSbnsW+6pYO6g4Kjaih8S1g8nAsbnRjjA30+pqYQxh2giUy
+2VuHAhmHRhoXAPadB0C0mVBJww7SWAYRw1dkHY+SgCevcZKuPfFgaUkFOlZFxvx13A==
+	]]>
+	<![CDATA[
+	EBbISFGmySREh+fIZhv5DMfMI2Yw5AMrFUigE0gMEIB0I1Xm6SY8lNEIEaMMSxiJoZ0SZFQmoIQt
+KHRGWIWh3+FLkbbOsagOweDo7rRRiyh5GOFA6ogSrytdRPiSMgXVAtQuyKYwqI0yKkh4vB1uuuKW
+MPFAlemRdzBEEs5RwPAE4rCiwQmAMImnuiGoY/qONu4gl6kzTBD0QApFsM0PxpEwGMYFTfOo++Cm
+N9mBpqEJEo8zDY3LBQyPwiAEnmyrA54V1DYZIBU8HAU3wmXcxS8TdxwnkIAVWT/ejgGlVjComWhR
+DO50ogoLhC7TMBoGjQqJbElzuOuK0ECF1uNxcOqghiKS7WHQsEQa74MOOhKQg2V6iAvRmhS9Hu4t
+IDhRQfUJ5kckiiyDu9GIJ9yhLtAQKSwj9M+b0VBYRFY0aqkSGTGnLxIO1T3ym6gntEAP6kBaF/Uy
+XLN0JRXIyUmoeDFUhebohzytTUpYRe+AIumUQr0PuLZE/dBEhgadkJXEEB1Soa4JHDDHFEgBo5D9
+dyzgqDKKIW2IcsSKIhrODYUhDAvjAMjEKOQoHBIHQM5SRAKm1gaWiAy1GiQaG4hlMm6xkyMaRT1+
+AIwhmYTcgC0qW3XoQiOBdiQ6oYDeF1xogkRLGB7PPcTFyKITltWDd2gkEMuztEyUSagfmlr0N4PL
+E2NcWBJxQ5YK8BRBwkAVbISgBLmMwNEmFCB8UqIHRjD0JAz6XYFHekYGjAxEQHUfA8pIgBJG/7nZ
+FaqTKz4y7K9G+VejdGiU3B/0CnN4wCioCSD0WbHwf2u7lhSEYSB6gtyhm+4U2/pBcaWiIBQU1AME
+GmpBUmnFz+2dlzRTPyCKusxrMpOkYWYSXiY2ogSnLgh+G1FWeqIGaTEK/hNSRl+cCr8TUobRZzkM
+LYHJMG/JF7R7IfjTjIF3hT0puMsUrHQMhXjQxX15+NG+ISNXSOVb7zAwM2EBwRzklsi2i0u5LL1G
+XB8m4hmLaww+gnbQJNRJB28uDHE64/rAyE2/GIsFj4gxHjVLf56bOg/g4PU/eWtpM2KSx9nL2z1y
+QL9d2P/OTUeT99GKa+HlD7z6QT0NvNasUGqjk5zqmxJZn7lO1NmWV2RFL65MNh7tRvqQyV0mSwyj
+IYbiUUM8tq+HTHVi3g5pNoXvL2Wq1oXMdqoQaSmPypNa5weaoj198dJClaRLeeU2PwGhJq66708X
+M3EF3zUAyQ==
+	]]>
+</i:pgf>
+</svg>


### PR DESCRIPTION
... repo (https://github.com/ptone/bc/commit/96ef9a486762f2c4d8e080e032344bbc8ce37f85).

These are currently in Adobe's idea of the SVG standard, which doesn't appear to be the same as much else's - so they display wrongly in both Inkscape and Firefox, and need some fixing up.